### PR TITLE
Add masked game view endpoint

### DIFF
--- a/src/routes/gameRoutes.js
+++ b/src/routes/gameRoutes.js
@@ -1,0 +1,64 @@
+const express = require('express');
+const router = express.Router();
+const Game = require('../models/Game');
+const ServerConfig = require('../models/ServerConfig');
+
+// Get a game from the perspective of a color
+router.get('/:id/color/:color', async (req, res) => {
+  try {
+    const { id, color } = req.params;
+    const normalized = String(color).toLowerCase();
+
+    let viewColor;
+    const isAdmin = normalized === 'admin';
+    const isSpectator = normalized === 'spectator';
+
+    if (!isAdmin && !isSpectator) {
+      viewColor = parseInt(normalized, 10);
+      if (viewColor !== 0 && viewColor !== 1) {
+        return res.status(400).json({ message: 'Invalid color' });
+      }
+    }
+
+    const game = await Game.findById(id).lean();
+    if (!game) {
+      return res.status(404).json({ message: 'Game not found' });
+    }
+
+    // Do not mask anything for admin view
+    if (isAdmin) {
+      return res.json(game);
+    }
+
+    const config = new ServerConfig();
+    const unknown = config.identities.get('UNKNOWN');
+
+    const maskPiece = (piece) => {
+      if (!piece) return piece;
+      if (isSpectator) {
+        return { ...piece, identity: unknown };
+      }
+      if (piece.color !== viewColor) {
+        return { ...piece, identity: unknown };
+      }
+      return piece;
+    };
+
+    if (Array.isArray(game.board)) {
+      game.board = game.board.map((row) => row.map(maskPiece));
+    }
+    if (Array.isArray(game.stashes)) {
+      game.stashes = game.stashes.map((stash) => stash.map(maskPiece));
+    }
+    if (Array.isArray(game.onDecks)) {
+      game.onDecks = game.onDecks.map(maskPiece);
+    }
+    // Captured pieces remain unchanged
+
+    res.json(game);
+  } catch (err) {
+    res.status(500).json({ message: err.message });
+  }
+});
+
+module.exports = router;

--- a/src/server.js
+++ b/src/server.js
@@ -7,6 +7,8 @@ require('dotenv').config();
 
 const app = express();
 
+const gameRoutes = require('./routes/gameRoutes');
+
 // Middleware
 app.use(cors());
 app.use(helmet());
@@ -23,6 +25,8 @@ mongoose.connect(process.env.MONGODB_URI || 'mongodb://localhost:27017/cloaks-ga
 app.get('/', (req, res) => {
   res.json({ message: 'Welcome to Cloaks Gambit API' });
 });
+
+app.use('/api/games', gameRoutes);
 
 // Error handling middleware
 app.use((err, req, res, next) => {


### PR DESCRIPTION
## Summary
- add `/api/games/:id/color/:color` endpoint to return a game's data from one player's perspective
- register new game routes in the server
- support admin and spectator views in masked game endpoint

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683e944d760c832aa94938519697fbaf