### PR TITLE
Implement match list retrieval

### DIFF
--- a/src/routes/v1/matches/getList.js
+++ b/src/routes/v1/matches/getList.js
@@ -1,11 +1,29 @@
 const express = require('express');
 const router = express.Router();
+const Match = require('../../../models/Match');
 
 router.post('/', async (req, res) => {
   try {
     const { userId, status } = req.body;
-    // TODO: Implement match list retrieval
-    res.status(501).json({ message: 'Not implemented yet' });
+
+    const query = {};
+    if (userId) {
+      query.$or = [
+        { player1: userId },
+        { player2: userId }
+      ];
+    }
+
+    if (status) {
+      query.isActive = status === 'active';
+    }
+
+    const matches = await Match.find(query)
+      .sort({ startTime: -1 })
+      .limit(50)
+      .lean();
+
+    res.json(matches);
   } catch (err) {
     res.status(500).json({ message: err.message });
   }


### PR DESCRIPTION
## Summary
- add Match model import
- filter matches by user and status
- query recent matches sorted by start time

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f341f045c832aad4daadd9fd03744