### PR TITLE
Implement match details retrieval route

### DIFF
--- a/src/routes/v1/matches/getDetails.js
+++ b/src/routes/v1/matches/getDetails.js
@@ -1,11 +1,27 @@
 const express = require('express');
 const router = express.Router();
+const Match = require('../../../models/Match');
 
 router.post('/', async (req, res) => {
   try {
     const { matchId } = req.body;
-    // TODO: Implement match details retrieval
-    res.status(501).json({ message: 'Not implemented yet' });
+
+    if (!matchId) {
+      return res.status(400).json({ message: 'matchId is required' });
+    }
+
+    const match = await Match.findById(matchId)
+      .populate('games')
+      .populate('player1')
+      .populate('player2')
+      .populate('winner')
+      .lean();
+
+    if (!match) {
+      return res.status(404).json({ message: 'Match not found' });
+    }
+
+    res.json(match);
   } catch (err) {
     res.status(500).json({ message: err.message });
   }


### PR DESCRIPTION
## Summary
- add Match model import
- validate `matchId`
- query Match by id with population and lean
- return 404 if not found
- return match details JSON on success

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f341ffcb4832aa2b4ede86249b7af