### PR TITLE
Resolve prior move effects

### DIFF
--- a/src/routes/v1/gameAction/move.js
+++ b/src/routes/v1/gameAction/move.js
@@ -121,7 +121,30 @@ router.post('/', async (req, res) => {
     };
 
     if (game.moves.length > 0) {
-      game.moves[game.moves.length - 1].state = config.moveStates.get('RESOLVED');
+      const prevMove = game.moves[game.moves.length - 1];
+
+      const { from: pf, to: pt } = prevMove;
+      const movingPiece = game.board[pf.row][pf.col];
+      const targetPiece = game.board[pt.row][pt.col];
+
+      if (targetPiece) {
+        game.captured[targetPiece.color].push(targetPiece);
+      }
+
+      game.board[pt.row][pt.col] = movingPiece;
+      game.board[pf.row][pf.col] = null;
+
+      const kingId = config.identities.get('KING');
+      if (targetPiece && targetPiece.identity === kingId) {
+        await game.endGame(prevMove.player, config.winReasons.get('CAPTURED_KING'));
+      } else if (prevMove.declaration === kingId) {
+        const throneRow = prevMove.player === 0 ? config.boardDimensions.RANKS - 1 : 0;
+        if (pt.row === throneRow) {
+          await game.endGame(prevMove.player, config.winReasons.get('THRONE'));
+        }
+      }
+
+      prevMove.state = config.moveStates.get('RESOLVED');
     }
 
     game.moves.push(move);


### PR DESCRIPTION
## Summary
- execute previous move when recording a new move
- capture pieces and update board
- trigger game over on king capture or throne

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f454c36f8832a990469cb5e1c677a