### PR TITLE
Add lobby schema and retrieval route

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,9 @@ npm start
 - GET /api/users - Get all users
 - POST /api/users - Create a new user
 
+### Lobby
+- POST /api/v1/lobby/get - Retrieve the current lobby queues
+
 ## Project Structure
 
 ```

--- a/src/models/Lobby.js
+++ b/src/models/Lobby.js
@@ -1,0 +1,14 @@
+const mongoose = require('mongoose');
+
+const lobbySchema = new mongoose.Schema({
+  quickplayQueue: [{
+    type: mongoose.Schema.Types.ObjectId,
+    ref: 'User'
+  }],
+  rankedQueue: [{
+    type: mongoose.Schema.Types.ObjectId,
+    ref: 'User'
+  }]
+}, { timestamps: true });
+
+module.exports = mongoose.model('Lobby', lobbySchema);

--- a/src/routes/v1/index.js
+++ b/src/routes/v1/index.js
@@ -23,6 +23,9 @@ const gameActionOnDeck = require('./gameAction/onDeck');
 const gameActionPass = require('./gameAction/pass');
 const gameActionResign = require('./gameAction/resign');
 
+// Lobby routes
+const lobbyGet = require('./lobby/get');
+
 // User routes
 router.use('/users/getList', userGetList);
 router.use('/users/getDetails', userGetDetails);
@@ -44,5 +47,8 @@ router.use('/gameAction/bomb', gameActionBomb);
 router.use('/gameAction/onDeck', gameActionOnDeck);
 router.use('/gameAction/pass', gameActionPass);
 router.use('/gameAction/resign', gameActionResign);
+
+// Lobby routes
+router.use('/lobby/get', lobbyGet);
 
 module.exports = router; 

--- a/src/routes/v1/lobby/get.js
+++ b/src/routes/v1/lobby/get.js
@@ -1,0 +1,18 @@
+const express = require('express');
+const router = express.Router();
+const Lobby = require('../../../models/Lobby');
+
+router.post('/', async (req, res) => {
+  try {
+    let lobby = await Lobby.findOne().lean();
+    if (!lobby) {
+      lobby = await Lobby.create({ quickplayQueue: [], rankedQueue: [] });
+      lobby = lobby.toObject();
+    }
+    res.json(lobby);
+  } catch (err) {
+    res.status(500).json({ message: err.message });
+  }
+});
+
+module.exports = router;


### PR DESCRIPTION
## Summary
- create `Lobby` MongoDB model storing user queues for quickplay and ranked modes
- expose `/api/v1/lobby/get` endpoint to retrieve or auto-create the lobby document
- register new route in API v1 router
- document lobby endpoint in README

## Testing
- `npm test` *(fails: jest not installed)*

------
https://chatgpt.com/codex/tasks/task_e_683f5578fd0c832a9acf0cb10d23a55d