### PR TITLE
Implement lobby queue routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,10 @@ npm start
 
 ### Lobby
 - POST /api/v1/lobby/get - Retrieve the current lobby queues
+- POST /api/v1/lobby/enterQuickplay - Join the quickplay queue
+- POST /api/v1/lobby/exitQuickplay - Leave the quickplay queue
+- POST /api/v1/lobby/enterRanked - Join the ranked queue
+- POST /api/v1/lobby/exitRanked - Leave the ranked queue
 
 ## Project Structure
 

--- a/src/routes/v1/index.js
+++ b/src/routes/v1/index.js
@@ -25,6 +25,10 @@ const gameActionResign = require('./gameAction/resign');
 
 // Lobby routes
 const lobbyGet = require('./lobby/get');
+const lobbyEnterQuickplay = require('./lobby/enterQuickplay');
+const lobbyExitQuickplay = require('./lobby/exitQuickplay');
+const lobbyEnterRanked = require('./lobby/enterRanked');
+const lobbyExitRanked = require('./lobby/exitRanked');
 
 // User routes
 router.use('/users/getList', userGetList);
@@ -50,5 +54,9 @@ router.use('/gameAction/resign', gameActionResign);
 
 // Lobby routes
 router.use('/lobby/get', lobbyGet);
+router.use('/lobby/enterQuickplay', lobbyEnterQuickplay);
+router.use('/lobby/exitQuickplay', lobbyExitQuickplay);
+router.use('/lobby/enterRanked', lobbyEnterRanked);
+router.use('/lobby/exitRanked', lobbyExitRanked);
 
 module.exports = router; 

--- a/src/routes/v1/lobby/enterQuickplay.js
+++ b/src/routes/v1/lobby/enterQuickplay.js
@@ -1,0 +1,35 @@
+const express = require('express');
+const router = express.Router();
+const Lobby = require('../../../models/Lobby');
+
+router.post('/', async (req, res) => {
+  try {
+    const { userId } = req.body;
+    if (!userId) {
+      return res.status(400).json({ message: 'User ID required' });
+    }
+
+    let lobby = await Lobby.findOne();
+    if (!lobby) {
+      lobby = await Lobby.create({ quickplayQueue: [], rankedQueue: [] });
+    }
+
+    if (lobby.quickplayQueue.some(id => id.toString() === userId)) {
+      return res
+        .status(400)
+        .json({ message: 'User already in quickplay queue' });
+    }
+    if (lobby.rankedQueue.some(id => id.toString() === userId)) {
+      return res.status(400).json({ message: 'User already in ranked queue' });
+    }
+
+    lobby.quickplayQueue.push(userId);
+    await lobby.save();
+
+    res.json({ message: 'Entered quickplay queue' });
+  } catch (err) {
+    res.status(500).json({ message: err.message });
+  }
+});
+
+module.exports = router;

--- a/src/routes/v1/lobby/enterRanked.js
+++ b/src/routes/v1/lobby/enterRanked.js
@@ -1,0 +1,35 @@
+const express = require('express');
+const router = express.Router();
+const Lobby = require('../../../models/Lobby');
+
+router.post('/', async (req, res) => {
+  try {
+    const { userId } = req.body;
+    if (!userId) {
+      return res.status(400).json({ message: 'User ID required' });
+    }
+
+    let lobby = await Lobby.findOne();
+    if (!lobby) {
+      lobby = await Lobby.create({ quickplayQueue: [], rankedQueue: [] });
+    }
+
+    if (lobby.rankedQueue.some(id => id.toString() === userId)) {
+      return res.status(400).json({ message: 'User already in ranked queue' });
+    }
+    if (lobby.quickplayQueue.some(id => id.toString() === userId)) {
+      return res
+        .status(400)
+        .json({ message: 'User already in quickplay queue' });
+    }
+
+    lobby.rankedQueue.push(userId);
+    await lobby.save();
+
+    res.json({ message: 'Entered ranked queue' });
+  } catch (err) {
+    res.status(500).json({ message: err.message });
+  }
+});
+
+module.exports = router;

--- a/src/routes/v1/lobby/exitQuickplay.js
+++ b/src/routes/v1/lobby/exitQuickplay.js
@@ -1,0 +1,28 @@
+const express = require('express');
+const router = express.Router();
+const Lobby = require('../../../models/Lobby');
+
+router.post('/', async (req, res) => {
+  try {
+    const { userId } = req.body;
+    if (!userId) {
+      return res.status(400).json({ message: 'User ID required' });
+    }
+
+    let lobby = await Lobby.findOne();
+    if (!lobby) {
+      lobby = await Lobby.create({ quickplayQueue: [], rankedQueue: [] });
+    }
+
+    lobby.quickplayQueue = lobby.quickplayQueue.filter(
+      (id) => id.toString() !== userId
+    );
+    await lobby.save();
+
+    res.json({ message: 'Exited quickplay queue' });
+  } catch (err) {
+    res.status(500).json({ message: err.message });
+  }
+});
+
+module.exports = router;

--- a/src/routes/v1/lobby/exitRanked.js
+++ b/src/routes/v1/lobby/exitRanked.js
@@ -1,0 +1,28 @@
+const express = require('express');
+const router = express.Router();
+const Lobby = require('../../../models/Lobby');
+
+router.post('/', async (req, res) => {
+  try {
+    const { userId } = req.body;
+    if (!userId) {
+      return res.status(400).json({ message: 'User ID required' });
+    }
+
+    let lobby = await Lobby.findOne();
+    if (!lobby) {
+      lobby = await Lobby.create({ quickplayQueue: [], rankedQueue: [] });
+    }
+
+    lobby.rankedQueue = lobby.rankedQueue.filter(
+      (id) => id.toString() !== userId
+    );
+    await lobby.save();
+
+    res.json({ message: 'Exited ranked queue' });
+  } catch (err) {
+    res.status(500).json({ message: err.message });
+  }
+});
+
+module.exports = router;


### PR DESCRIPTION
## Summary
- add enter/exit routes for quickplay and ranked lobby queues
- document lobby queue routes in README

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f56e79638832aa363ae8f452eb0ca