### PR TITLE
Check move state before resolve

### DIFF
--- a/src/routes/v1/gameAction/move.js
+++ b/src/routes/v1/gameAction/move.js
@@ -123,28 +123,30 @@ router.post('/', async (req, res) => {
     if (game.moves.length > 0) {
       const prevMove = game.moves[game.moves.length - 1];
 
-      const { from: pf, to: pt } = prevMove;
-      const movingPiece = game.board[pf.row][pf.col];
-      const targetPiece = game.board[pt.row][pt.col];
+      if (prevMove.state === config.moveStates.get('PENDING')) {
+        const { from: pf, to: pt } = prevMove;
+        const movingPiece = game.board[pf.row][pf.col];
+        const targetPiece = game.board[pt.row][pt.col];
 
-      if (targetPiece) {
-        game.captured[targetPiece.color].push(targetPiece);
-      }
-
-      game.board[pt.row][pt.col] = movingPiece;
-      game.board[pf.row][pf.col] = null;
-
-      const kingId = config.identities.get('KING');
-      if (targetPiece && targetPiece.identity === kingId) {
-        await game.endGame(prevMove.player, config.winReasons.get('CAPTURED_KING'));
-      } else if (prevMove.declaration === kingId) {
-        const throneRow = prevMove.player === 0 ? config.boardDimensions.RANKS - 1 : 0;
-        if (pt.row === throneRow) {
-          await game.endGame(prevMove.player, config.winReasons.get('THRONE'));
+        if (targetPiece) {
+          game.captured[targetPiece.color].push(targetPiece);
         }
-      }
 
-      prevMove.state = config.moveStates.get('RESOLVED');
+        game.board[pt.row][pt.col] = movingPiece;
+        game.board[pf.row][pf.col] = null;
+
+        const kingId = config.identities.get('KING');
+        if (targetPiece && targetPiece.identity === kingId) {
+          await game.endGame(prevMove.player, config.winReasons.get('CAPTURED_KING'));
+        } else if (prevMove.declaration === kingId) {
+          const throneRow = prevMove.player === 0 ? config.boardDimensions.RANKS - 1 : 0;
+          if (pt.row === throneRow) {
+            await game.endGame(prevMove.player, config.winReasons.get('THRONE'));
+          }
+        }
+
+        prevMove.state = config.moveStates.get('RESOLVED');
+      }
     }
 
     game.moves.push(move);

--- a/tests/moveResolution.test.js
+++ b/tests/moveResolution.test.js
@@ -1,0 +1,70 @@
+const request = require('supertest');
+const express = require('express');
+const moveRoute = require('../src/routes/v1/gameAction/move');
+const Game = require('../src/models/Game');
+const ServerConfig = require('../src/models/ServerConfig');
+
+const app = express();
+app.use(express.json());
+app.use('/', moveRoute);
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+test('previous move is not applied again when already resolved', async () => {
+  const config = new ServerConfig();
+
+  const pieceA = { color: 0, identity: config.identities.get('ROOK') };
+  const pieceB = { color: 1, identity: config.identities.get('KNIGHT') };
+
+  const ranks = config.boardDimensions.RANKS;
+  const files = config.boardDimensions.FILES;
+  const board = Array.from({ length: ranks }, () => Array(files).fill(null));
+
+  board[1][0] = pieceA; // result of previous resolved move
+  board[0][1] = pieceB; // piece to move
+
+  const game = {
+    board,
+    moves: [
+      {
+        player: 0,
+        from: { row: 0, col: 0 },
+        to: { row: 1, col: 0 },
+        declaration: config.identities.get('ROOK'),
+        state: config.moveStates.get('RESOLVED'),
+      },
+    ],
+    actions: [],
+    captured: [[], []],
+    setupComplete: [true, true],
+    onDeckingPlayer: null,
+    playerTurn: 1,
+    isActive: true,
+    addAction: jest.fn().mockResolvedValue(),
+    save: jest.fn().mockResolvedValue(),
+    endGame: jest.fn().mockResolvedValue(),
+  };
+
+  Game.findById = jest.fn().mockResolvedValue(game);
+
+  await request(app)
+    .post('/')
+    .send({
+      gameId: '1',
+      color: 1,
+      from: { row: 0, col: 1 },
+      to: { row: 0, col: 2 },
+      declaration: config.identities.get('KNIGHT'),
+    })
+    .expect(200);
+
+  // piece A should remain at its resolved position
+  expect(game.board[1][0]).toBe(pieceA);
+  expect(game.captured[0]).toHaveLength(0);
+
+  // piece B should have moved
+  expect(game.board[0][1]).toBe(null);
+  expect(game.board[0][2]).toBe(pieceB);
+});


### PR DESCRIPTION
## Summary
- avoid resolving last move multiple times
- test for resolved moves staying on board

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f75f24078832abe72c1783bcd6189