### PR TITLE
Implement draw counter for inactive moves

### DIFF
--- a/src/models/Game.js
+++ b/src/models/Game.js
@@ -228,6 +228,11 @@ const gameSchema = new mongoose.Schema({
             message: 'Daggers must contain exactly two non-negative numbers'
         }
     },
+    movesSinceAction: {
+        type: Number,
+        default: 0,
+        min: 0
+    },
     setupComplete: {
         type: [Boolean],
         default: [false, false],

--- a/src/models/ServerConfig.js
+++ b/src/models/ServerConfig.js
@@ -109,7 +109,8 @@ const serverConfigSchema = new mongoose.Schema({
       DAGGERS: 3,
       TIME_CONTROL: 4,
       DISCONNECT: 5,
-      RESIGN: 6
+      RESIGN: 6,
+      DRAW: 7
     }
   },
   gameActionStates: {

--- a/src/routes/v1/gameAction/bomb.js
+++ b/src/routes/v1/gameAction/bomb.js
@@ -47,6 +47,7 @@ router.post('/', async (req, res) => {
     }
 
     await game.addAction(config.actions.get('BOMB'), normalizedColor, {});
+    // Bomb does not alter the inactivity counter
 
     // Flip the turn to the other player
     game.playerTurn = normalizedColor === 0 ? 1 : 0;

--- a/src/routes/v1/gameAction/challenge.js
+++ b/src/routes/v1/gameAction/challenge.js
@@ -146,6 +146,7 @@ router.post('/', async (req, res) => {
     }
 
     await game.addAction(config.actions.get('CHALLENGE'), normalizedColor, {});
+    game.movesSinceAction = 0;
 
     if (trueKing && game.isActive) {
       await game.endGame(lastMove.player, config.winReasons.get('TRUE_KING'));

--- a/src/routes/v1/gameAction/move.js
+++ b/src/routes/v1/gameAction/move.js
@@ -145,6 +145,22 @@ router.post('/', async (req, res) => {
       }
 
       prevMove.state = config.moveStates.get('RESOLVED');
+
+      if (targetPiece) {
+        game.movesSinceAction = 0;
+      } else {
+        game.movesSinceAction += 1;
+        if (game.movesSinceAction >= 20 && game.isActive) {
+          game.winReason = config.winReasons.get('DRAW');
+          game.endTime = new Date();
+          game.isActive = false;
+        }
+      }
+    }
+
+    if (!game.isActive) {
+      await game.save();
+      return res.json({ message: 'Game drawn by inactivity' });
     }
 
     game.moves.push(move);

--- a/src/routes/v1/gameAction/onDeck.js
+++ b/src/routes/v1/gameAction/onDeck.js
@@ -61,6 +61,7 @@ router.post('/', async (req, res) => {
       details: { identity },
       timestamp: new Date(),
     });
+    // On deck placement does not affect the inactivity counter
 
     await game.save();
 

--- a/src/routes/v1/gameAction/pass.js
+++ b/src/routes/v1/gameAction/pass.js
@@ -50,6 +50,7 @@ router.post('/', async (req, res) => {
     lastMove.state = config.moveStates.get('RESOLVED');
 
     await game.addAction(config.actions.get('PASS'), normalizedColor, {});
+    game.movesSinceAction = 0;
 
     if (piece.identity === config.identities.get('KING') && game.isActive) {
       await game.endGame(normalizedColor, config.winReasons.get('CAPTURED_KING'));


### PR DESCRIPTION
## Summary
- track consecutive resolved moves with no action in Game schema
- add DRAW win reason constant
- update move logic to increment/reset counter and trigger draw
- reset counter after challenges and passes
- note that bombs/onDeck do not modify the counter

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f75f3334c832a9839bb908a6a3a0f