### PR TITLE
Add basic creation routes and Game timestamp field

### DIFF
--- a/src/models/Game.js
+++ b/src/models/Game.js
@@ -109,9 +109,12 @@ const gameSchema = new mongoose.Schema({
             message: 'Win reason must be specified when game is ended'
         }
     },
-    startTime: {
+    createdAt: {
         type: Date,
         default: Date.now
+    },
+    startTime: {
+        type: Date
     },
     endTime: {
         type: Date,

--- a/src/routes/v1/games/create.js
+++ b/src/routes/v1/games/create.js
@@ -1,0 +1,14 @@
+const express = require('express');
+const router = express.Router();
+const Game = require('../../../models/Game');
+
+router.post('/', async (req, res) => {
+  try {
+    const game = await Game.create(req.body);
+    res.status(201).json(game);
+  } catch (err) {
+    res.status(500).json({ message: err.message });
+  }
+});
+
+module.exports = router;

--- a/src/routes/v1/index.js
+++ b/src/routes/v1/index.js
@@ -4,14 +4,17 @@ const router = express.Router();
 // User routes
 const userGetList = require('./users/getList');
 const userGetDetails = require('./users/getDetails');
+const userCreate = require('./users/create');
 
 // Match routes
 const matchGetList = require('./matches/getList');
 const matchGetDetails = require('./matches/getDetails');
+const matchCreate = require('./matches/create');
 
 // Game routes
 const gameGetList = require('./games/getList');
 const gameGetDetails = require('./games/getDetails');
+const gameCreate = require('./games/create');
 
 // Game action routes
 const gameActionCheckTimeControl = require('./gameAction/checkTimeControl');
@@ -33,14 +36,17 @@ const lobbyExitRanked = require('./lobby/exitRanked');
 // User routes
 router.use('/users/getList', userGetList);
 router.use('/users/getDetails', userGetDetails);
+router.use('/users/create', userCreate);
 
 // Match routes
 router.use('/matches/getList', matchGetList);
 router.use('/matches/getDetails', matchGetDetails);
+router.use('/matches/create', matchCreate);
 
 // Game routes
 router.use('/games/getList', gameGetList);
 router.use('/games/getDetails', gameGetDetails);
+router.use('/games/create', gameCreate);
 
 // Game action routes
 router.use('/gameAction/checkTimeControl', gameActionCheckTimeControl);

--- a/src/routes/v1/matches/create.js
+++ b/src/routes/v1/matches/create.js
@@ -1,0 +1,14 @@
+const express = require('express');
+const router = express.Router();
+const Match = require('../../../models/Match');
+
+router.post('/', async (req, res) => {
+  try {
+    const match = await Match.create(req.body);
+    res.status(201).json(match);
+  } catch (err) {
+    res.status(500).json({ message: err.message });
+  }
+});
+
+module.exports = router;

--- a/src/routes/v1/users/create.js
+++ b/src/routes/v1/users/create.js
@@ -1,0 +1,19 @@
+const express = require('express');
+const router = express.Router();
+const User = require('../../../models/User');
+
+router.post('/', async (req, res) => {
+  try {
+    const { username, email } = req.body;
+    if (!username || !email) {
+      return res.status(400).json({ message: 'username and email are required' });
+    }
+
+    const user = await User.create({ username, email });
+    res.status(201).json(user);
+  } catch (err) {
+    res.status(500).json({ message: err.message });
+  }
+});
+
+module.exports = router;


### PR DESCRIPTION
## Summary
- add POST routes to create users, matches, and games
- expose the new routes in the v1 router
- add a `createdAt` field to Game model and make `startTime` optional

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f7aabddc4832a871b39d411a9f8ec