### PR TITLE
Add match requirement and player ready action

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ npm start
 - POST /api/v1/gameAction/onDeck - Move a piece on deck
 - POST /api/v1/gameAction/pass - Pass the turn
 - POST /api/v1/gameAction/resign - Resign from the game
+- POST /api/v1/gameAction/ready - Mark a player as ready
 
 ### Lobby
 - POST /api/v1/lobby/get - Retrieve the current lobby queues

--- a/src/models/Game.js
+++ b/src/models/Game.js
@@ -84,6 +84,21 @@ const gameSchema = new mongoose.Schema({
         },
         required: true
     },
+    match: {
+        type: mongoose.Schema.Types.ObjectId,
+        ref: 'Match',
+        required: true
+    },
+    playersReady: {
+        type: [Boolean],
+        default: [false, false],
+        validate: {
+            validator: function(v) {
+                return v.length === 2;
+            },
+            message: 'Players ready must contain exactly two boolean values'
+        }
+    },
     playerTurn: {
         type: Number,
         enum: [null, 0, 1],

--- a/src/models/ServerConfig.js
+++ b/src/models/ServerConfig.js
@@ -41,7 +41,8 @@ const serverConfigSchema = new mongoose.Schema({
       BOMB: 3,
       PASS: 4,
       ON_DECK: 5,
-      RESIGN: 6
+      RESIGN: 6,
+      READY: 7
     }
   },
   moveStates: {

--- a/src/routes/v1/gameAction/ready.js
+++ b/src/routes/v1/gameAction/ready.js
@@ -1,0 +1,41 @@
+const express = require('express');
+const router = express.Router();
+const Game = require('../../../models/Game');
+const ServerConfig = require('../../../models/ServerConfig');
+
+router.post('/', async (req, res) => {
+  try {
+    const { gameId, color } = req.body;
+
+    const game = await Game.findById(gameId);
+    if (!game) {
+      return res.status(404).json({ message: 'Game not found' });
+    }
+
+    const normalizedColor = parseInt(color, 10);
+    if (normalizedColor !== 0 && normalizedColor !== 1) {
+      return res.status(400).json({ message: 'Invalid color' });
+    }
+
+    if (game.playersReady[normalizedColor]) {
+      return res.status(400).json({ message: 'Player already ready' });
+    }
+
+    const config = new ServerConfig();
+
+    game.playersReady[normalizedColor] = true;
+    await game.addAction(config.actions.get('READY'), normalizedColor, {});
+
+    if (game.playersReady[0] && game.playersReady[1] && !game.startTime) {
+      game.startTime = new Date();
+    }
+
+    await game.save();
+
+    res.json({ message: 'Player marked ready' });
+  } catch (err) {
+    res.status(500).json({ message: err.message });
+  }
+});
+
+module.exports = router;

--- a/src/routes/v1/games/create.js
+++ b/src/routes/v1/games/create.js
@@ -1,10 +1,26 @@
 const express = require('express');
 const router = express.Router();
 const Game = require('../../../models/Game');
+const Match = require('../../../models/Match');
 
 router.post('/', async (req, res) => {
   try {
-    const game = await Game.create(req.body);
+    const { matchId, ...gameData } = req.body;
+
+    if (!matchId) {
+      return res.status(400).json({ message: 'matchId is required' });
+    }
+
+    const match = await Match.findById(matchId);
+    if (!match) {
+      return res.status(404).json({ message: 'Match not found' });
+    }
+
+    const game = await Game.create({ ...gameData, match: matchId });
+
+    match.games.push(game._id);
+    await match.save();
+
     res.status(201).json(game);
   } catch (err) {
     res.status(500).json({ message: err.message });

--- a/src/routes/v1/index.js
+++ b/src/routes/v1/index.js
@@ -25,6 +25,7 @@ const gameActionBomb = require('./gameAction/bomb');
 const gameActionOnDeck = require('./gameAction/onDeck');
 const gameActionPass = require('./gameAction/pass');
 const gameActionResign = require('./gameAction/resign');
+const gameActionReady = require('./gameAction/ready');
 
 // Lobby routes
 const lobbyGet = require('./lobby/get');
@@ -57,6 +58,7 @@ router.use('/gameAction/bomb', gameActionBomb);
 router.use('/gameAction/onDeck', gameActionOnDeck);
 router.use('/gameAction/pass', gameActionPass);
 router.use('/gameAction/resign', gameActionResign);
+router.use('/gameAction/ready', gameActionReady);
 
 // Lobby routes
 router.use('/lobby/get', lobbyGet);


### PR DESCRIPTION
## Summary
- require `matchId` when creating games and add them to the match
- track player readiness for games
- start the game timer once both players are ready
- expose a new `ready` game action endpoint
- document the new endpoint

## Testing
- `npx jest --runInBand` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_683f7ce563bc832ab631a1fec366f478