### PR TITLE
Handle match updates when a game ends

### DIFF
--- a/src/routes/v1/gameAction/checkTimeControl.js
+++ b/src/routes/v1/gameAction/checkTimeControl.js
@@ -26,28 +26,16 @@ router.post('/', async (req, res) => {
     const setup0 = game.setupComplete[0];
     const setup1 = game.setupComplete[1];
 
-    // Helper to save game without validation when needed
-    const saveGame = async (validate) => {
-      await game.save({ validateBeforeSave: validate });
-    };
-
     if (!setup0 || !setup1) {
       if (elapsed > timeControl) {
-        const winReason = config.winReasons.get('TIME_CONTROL');
-        const endTime = new Date(game.startTime.getTime() + timeControl);
-        game.winReason = winReason;
-        game.endTime = endTime;
-        game.isActive = false;
-
         if (!setup0 && !setup1) {
-          // Draw scenario - no winner field stored
-          await saveGame(false);
+          await game.endGame(null, config.winReasons.get('TIME_CONTROL'));
           return res.json({ gameOver: true, draw: true });
         }
 
-        game.winner = setup0 ? 0 : 1;
-        await saveGame(true);
-        return res.json({ gameOver: true, winner: game.winner });
+        const winnerColor = setup0 ? 0 : 1;
+        await game.endGame(winnerColor, config.winReasons.get('TIME_CONTROL'));
+        return res.json({ gameOver: true, winner: winnerColor });
       }
 
       return res.json({ gameOver: false });
@@ -57,15 +45,9 @@ router.post('/', async (req, res) => {
     const turnPlayer = game.playerTurn;
     const actionsCount = game.actions.filter(a => a.player === turnPlayer).length;
     if (elapsed + actionsCount * increment > timeControl) {
-      const winReason = config.winReasons.get('TIME_CONTROL');
-      const endTimeMs = game.startTime.getTime() + timeControl - actionsCount * increment;
-      game.winReason = winReason;
-      game.winner = turnPlayer === 0 ? 1 : 0;
-      game.endTime = new Date(endTimeMs);
-      game.isActive = false;
-      await saveGame(true);
-
-      return res.json({ gameOver: true, winner: game.winner });
+      const winnerColor = turnPlayer === 0 ? 1 : 0;
+      await game.endGame(winnerColor, config.winReasons.get('TIME_CONTROL'));
+      return res.json({ gameOver: true, winner: winnerColor });
     }
 
     return res.json({ gameOver: false });

--- a/src/routes/v1/gameAction/move.js
+++ b/src/routes/v1/gameAction/move.js
@@ -152,16 +152,13 @@ router.post('/', async (req, res) => {
         } else {
           game.movesSinceAction += 1;
           if (game.movesSinceAction >= 20 && game.isActive) {
-            game.winReason = config.winReasons.get('DRAW');
-            game.endTime = new Date();
-            game.isActive = false;
+            await game.endGame(null, config.winReasons.get('DRAW'));
           }
         }
       }
     }
 
     if (!game.isActive) {
-      await game.save();
       return res.json({ message: 'Game drawn by inactivity' });
     }
 


### PR DESCRIPTION
## Summary
- update `endGame` to manage match score and spawn next game
- use new endGame logic from move and time control endpoints

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f7e2910c4832ab7d9b093d454b26c