### PR TITLE
Add listenForMove route and utils

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ npm start
 ### Games
 - POST /api/v1/games/getList - Get a list of games
 - POST /api/v1/games/getDetails - Get details for a specific game
+- POST /api/v1/games/listenForMove - Poll for the opponent's next action
 
 ### Game Actions
 - POST /api/v1/gameAction/checkTimeControl - Check the current player's clock

--- a/src/routes/v1/games/getDetails.js
+++ b/src/routes/v1/games/getDetails.js
@@ -1,7 +1,7 @@
 const express = require('express');
 const router = express.Router();
 const Game = require('../../../models/Game');
-const ServerConfig = require('../../../models/ServerConfig');
+const maskGameForColor = require('../../../utils/gameView');
 
 router.post('/', async (req, res) => {
   try {
@@ -29,31 +29,8 @@ router.post('/', async (req, res) => {
       return res.json(game);
     }
 
-    const config = new ServerConfig();
-    const unknown = config.identities.get('UNKNOWN');
-
-    const maskPiece = (piece) => {
-      if (!piece) return piece;
-      if (isSpectator) {
-        return { ...piece, identity: unknown };
-      }
-      if (piece.color !== viewColor) {
-        return { ...piece, identity: unknown };
-      }
-      return piece;
-    };
-
-    if (Array.isArray(game.board)) {
-      game.board = game.board.map((row) => row.map(maskPiece));
-    }
-    if (Array.isArray(game.stashes)) {
-      game.stashes = game.stashes.map((stash) => stash.map(maskPiece));
-    }
-    if (Array.isArray(game.onDecks)) {
-      game.onDecks = game.onDecks.map(maskPiece);
-    }
-
-    res.json(game);
+    const masked = maskGameForColor(game, normalized);
+    res.json(masked);
   } catch (err) {
     res.status(500).json({ message: err.message });
   }

--- a/src/routes/v1/games/listenForMove.js
+++ b/src/routes/v1/games/listenForMove.js
@@ -1,0 +1,69 @@
+const express = require('express');
+const router = express.Router();
+const Game = require('../../../models/Game');
+const maskGameForColor = require('../../../utils/gameView');
+
+const POLL_INTERVAL = 1000; // 1 second
+const TIMEOUT = 30000; // 30 seconds
+
+router.post('/', async (req, res) => {
+  try {
+    const { gameId, color, lastAction } = req.body;
+    const normalized = String(color).toLowerCase();
+
+    let viewColor;
+    const isAdmin = normalized === 'admin';
+    const isSpectator = normalized === 'spectator';
+
+    if (!isAdmin && !isSpectator) {
+      viewColor = parseInt(normalized, 10);
+      if (viewColor !== 0 && viewColor !== 1) {
+        return res.status(400).json({ message: 'Invalid color' });
+      }
+    }
+
+    const start = Date.now();
+    while (Date.now() - start < TIMEOUT) {
+      const game = await Game.findById(gameId).lean();
+      if (!game) {
+        return res.status(404).json({ message: 'Game not found' });
+      }
+
+      const actions = Array.isArray(game.actions) ? game.actions : [];
+      let found = false;
+
+      if (lastAction !== undefined && lastAction !== null) {
+        const idx = parseInt(lastAction, 10);
+        if (!isNaN(idx)) {
+          for (let i = idx + 1; i < actions.length; i++) {
+            const a = actions[i];
+            if (isAdmin || isSpectator ? true : a.player !== viewColor) {
+              found = true;
+              break;
+            }
+          }
+        } else {
+          const ts = new Date(lastAction);
+          if (!isNaN(ts.getTime())) {
+            found = actions.some(a =>
+              new Date(a.timestamp) > ts && (isAdmin || isSpectator ? true : a.player !== viewColor)
+            );
+          }
+        }
+      }
+
+      if (found) {
+        const masked = maskGameForColor(game, normalized);
+        return res.json(masked);
+      }
+
+      await new Promise(resolve => setTimeout(resolve, POLL_INTERVAL));
+    }
+
+    return res.status(204).end();
+  } catch (err) {
+    res.status(500).json({ message: err.message });
+  }
+});
+
+module.exports = router;

--- a/src/routes/v1/index.js
+++ b/src/routes/v1/index.js
@@ -15,6 +15,7 @@ const matchCreate = require('./matches/create');
 const gameGetList = require('./games/getList');
 const gameGetDetails = require('./games/getDetails');
 const gameCreate = require('./games/create');
+const gamesListenForMove = require('./games/listenForMove');
 
 // Game action routes
 const gameActionCheckTimeControl = require('./gameAction/checkTimeControl');
@@ -48,6 +49,7 @@ router.use('/matches/create', matchCreate);
 router.use('/games/getList', gameGetList);
 router.use('/games/getDetails', gameGetDetails);
 router.use('/games/create', gameCreate);
+router.use('/games/listenForMove', gamesListenForMove);
 
 // Game action routes
 router.use('/gameAction/checkTimeControl', gameActionCheckTimeControl);

--- a/src/utils/gameView.js
+++ b/src/utils/gameView.js
@@ -1,0 +1,37 @@
+const ServerConfig = require('../models/ServerConfig');
+
+function maskGameForColor(game, color) {
+  const normalized = String(color).toLowerCase();
+  const isAdmin = normalized === 'admin';
+  const isSpectator = normalized === 'spectator';
+  const viewColor = !isAdmin && !isSpectator ? parseInt(normalized, 10) : undefined;
+
+  if (isAdmin) {
+    return game;
+  }
+
+  const config = new ServerConfig();
+  const unknown = config.identities.get('UNKNOWN');
+
+  const maskPiece = (piece) => {
+    if (!piece) return piece;
+    if (isSpectator || piece.color !== viewColor) {
+      return { ...piece, identity: unknown };
+    }
+    return piece;
+  };
+
+  if (Array.isArray(game.board)) {
+    game.board = game.board.map((row) => row.map(maskPiece));
+  }
+  if (Array.isArray(game.stashes)) {
+    game.stashes = game.stashes.map((stash) => stash.map(maskPiece));
+  }
+  if (Array.isArray(game.onDecks)) {
+    game.onDecks = game.onDecks.map(maskPiece);
+  }
+
+  return game;
+}
+
+module.exports = maskGameForColor;

--- a/tests/listenForMove.test.js
+++ b/tests/listenForMove.test.js
@@ -1,0 +1,60 @@
+const request = require('supertest');
+const express = require('express');
+const listenRoute = require('../src/routes/v1/games/listenForMove');
+const Game = require('../src/models/Game');
+const ServerConfig = require('../src/models/ServerConfig');
+
+const app = express();
+app.use(express.json());
+app.use('/', listenRoute);
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  jest.useFakeTimers();
+});
+
+afterEach(() => {
+  jest.useRealTimers();
+});
+
+test('polling resolves when an opponent action is added', async () => {
+  const config = new ServerConfig();
+  const board = [[{ color: 1, identity: config.identities.get('ROOK') }]];
+  const baseGame = { actions: [{ player: 0, type: 1, details: {}, timestamp: new Date() }], board, stashes: [[], []], onDecks: [] };
+  const gameWithAction = { ...baseGame, actions: [...baseGame.actions, { player: 1, type: 1, details: {}, timestamp: new Date() }] };
+
+  Game.findById = jest.fn()
+    .mockResolvedValueOnce(baseGame)
+    .mockResolvedValueOnce(baseGame)
+    .mockResolvedValueOnce(gameWithAction);
+
+  const req = request(app)
+    .post('/')
+    .send({ gameId: '1', color: 0, lastAction: 0 });
+
+  await jest.advanceTimersByTimeAsync(2000);
+  const res = await req;
+
+  expect(res.status).toBe(200);
+  const unknown = config.identities.get('UNKNOWN');
+  expect(res.body.board[0][0].identity).toBe(unknown);
+  expect(Game.findById).toHaveBeenCalledTimes(3);
+});
+
+test('returns 204 when no new action occurs before timeout', async () => {
+  const config = new ServerConfig();
+  const board = [[{ color: 1, identity: config.identities.get('ROOK') }]];
+  const baseGame = { actions: [{ player: 0, type: 1, details: {}, timestamp: new Date() }], board, stashes: [[], []], onDecks: [] };
+
+  Game.findById = jest.fn().mockResolvedValue(baseGame);
+
+  const req = request(app)
+    .post('/')
+    .send({ gameId: '1', color: 0, lastAction: 0 });
+
+  await jest.advanceTimersByTimeAsync(31000);
+  const res = await req;
+
+  expect(res.status).toBe(204);
+  expect(Game.findById).toHaveBeenCalled();
+});


### PR DESCRIPTION
## Summary
- add new `maskGameForColor` utility
- refactor getDetails to use the utility
- implement `/games/listenForMove` polling route
- register new route and document endpoint
- add tests for listenForMove

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f92ab4de4832a957e52ed8d175bf5