### PR TITLE
Document listenForMove usage and add client polling test

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,3 +73,34 @@ src/
 ├── routes/         # API routes
 └── server.js       # Application entry point
 ```
+
+## Listening for Moves
+
+Use the `/api/v1/games/listenForMove` endpoint after each action to stay
+synchronized with your opponent. Send a POST request with `gameId`, `color`
+and the `lastAction` index or timestamp you have processed. If a new
+opponent action occurs before the 30 second timeout, the route returns the
+updated game state with HTTP `200`. Otherwise it returns `204` and you should
+immediately issue another poll.
+
+Example client logic (using `fetch`):
+
+```javascript
+async function listenLoop(gameId, color, lastAction) {
+  const body = JSON.stringify({ gameId, color, lastAction });
+  const res = await fetch('/api/v1/games/listenForMove', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body,
+  });
+
+  if (res.status === 200) {
+    const game = await res.json();
+    // handle updated game state here
+    return game;
+  }
+
+  // status 204 indicates no action; call again
+  return listenLoop(gameId, color, lastAction);
+}
+```

--- a/tests/clientPolling.test.js
+++ b/tests/clientPolling.test.js
@@ -1,0 +1,61 @@
+const request = require('supertest');
+const express = require('express');
+const listenRoute = require('../src/routes/v1/games/listenForMove');
+const Game = require('../src/models/Game');
+const ServerConfig = require('../src/models/ServerConfig');
+
+const app = express();
+app.use(express.json());
+app.use('/', listenRoute);
+
+// simple client side polling function
+async function longPoll(gameId, color, lastAction) {
+  // this loops until the server indicates there is a new action
+  while (true) {
+    const res = await request(app)
+      .post('/')
+      .send({ gameId, color, lastAction });
+
+    if (res.status === 200) {
+      return res.body;
+    }
+
+    if (res.status !== 204) {
+      throw new Error(`Unexpected status ${res.status}`);
+    }
+
+    // wait before sending the next poll
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  }
+}
+
+beforeEach(() => {
+  jest.useFakeTimers();
+  jest.clearAllMocks();
+});
+
+afterEach(() => {
+  jest.useRealTimers();
+});
+
+test('client polling repeats until a new action is received', async () => {
+  const config = new ServerConfig();
+  const board = [[{ color: 1, identity: config.identities.get('ROOK') }]];
+  const baseGame = { actions: [{ player: 0, type: 1, details: {}, timestamp: new Date() }], board, stashes: [[], []], onDecks: [] };
+  const updated = { ...baseGame, actions: [...baseGame.actions, { player: 1, type: 1, details: {}, timestamp: new Date() }] };
+
+  Game.findById = jest.fn()
+    .mockResolvedValueOnce(baseGame)
+    .mockResolvedValueOnce(baseGame)
+    .mockResolvedValueOnce(updated);
+
+  const pollPromise = longPoll('1', 0, 0);
+
+  await jest.advanceTimersByTimeAsync(31000); // first server timeout
+  await jest.advanceTimersByTimeAsync(31000); // second server timeout
+  await jest.advanceTimersByTimeAsync(2000);  // third call resolves
+
+  const result = await pollPromise;
+  expect(result.board[0][0].identity).toBe(config.identities.get('UNKNOWN'));
+  expect(Game.findById).toHaveBeenCalledTimes(3);
+});


### PR DESCRIPTION
## Summary
- document how to use the long polling endpoint
- add a Jest test that demonstrates a client loop polling for updates

## Testing
- `npm test` *(fails: jest not found)*
- `npx jest` *(fails: forbidden to fetch jest from registry)*

------
https://chatgpt.com/codex/tasks/task_e_684070de1450832a86288d87a5a7e6aa