### PR TITLE
docs: note websocket realtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Cloaks Gambit API
 
-A REST API application built with Node.js and MongoDB.
+A REST API application built with Node.js and MongoDB. Real-time match and move
+updates are delivered through WebSocket events.
 
 ## Prerequisites
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -1,0 +1,35 @@
+# API Documentation
+
+This document lists the REST endpoints exposed by the Cloaks Gambit API. Real-
+time match and move data is streamed to clients via WebSocket events.
+
+## Users
+- `POST /api/v1/users/getList` – Retrieve users with optional filters
+- `POST /api/v1/users/getDetails` – Get details for a specific user
+
+## Matches
+- `POST /api/v1/matches/getList` – Get a list of matches
+- `POST /api/v1/matches/getDetails` – Get details for a specific match
+
+## Games
+- `POST /api/v1/games/getList` – Get a list of games
+- `POST /api/v1/games/getDetails` – Get details for a specific game
+
+## Game Actions
+- `POST /api/v1/gameAction/checkTimeControl` – Check the current player's clock
+- `POST /api/v1/gameAction/setup` – Set up a game board
+- `POST /api/v1/gameAction/move` – Submit a piece move
+- `POST /api/v1/gameAction/challenge` – Challenge an opponent's move
+- `POST /api/v1/gameAction/bomb` – Bomb the last move
+- `POST /api/v1/gameAction/onDeck` – Move a piece on deck
+- `POST /api/v1/gameAction/pass` – Pass the turn
+- `POST /api/v1/gameAction/resign` – Resign from the game
+- `POST /api/v1/gameAction/ready` – Mark a player as ready
+
+## Lobby
+- `POST /api/v1/lobby/get` – Retrieve the current lobby queues
+- `POST /api/v1/lobby/enterQuickplay` – Join the quickplay queue
+- `POST /api/v1/lobby/exitQuickplay` – Leave the quickplay queue
+- `POST /api/v1/lobby/enterRanked` – Join the ranked queue
+- `POST /api/v1/lobby/exitRanked` – Leave the ranked queue
+


### PR DESCRIPTION
## Summary
- clarify in README that real-time match and move updates use WebSocket events
- add dedicated API documentation excluding deprecated listen endpoints

## Testing
- `npm test`
- `PYTHONPATH=scripts pytest`


------
https://chatgpt.com/codex/tasks/task_e_6897afdf6b04832a8b0eac5115f55e25