### PR TITLE
Add socket initialization

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "jsonwebtoken": "^9.0.2",
     "mongoose": "^8.1.0",
     "morgan": "^1.10.0",
-    "winston": "^3.17.0"
+    "winston": "^3.17.0",
+    "socket.io": "^4.7.2"
   },
   "devDependencies": {
     "jest": "^29.7.0",

--- a/src/server.js
+++ b/src/server.js
@@ -1,4 +1,5 @@
 const express = require('express');
+const http = require('http');
 const mongoose = require('mongoose');
 const cors = require('cors');
 const helmet = require('helmet');
@@ -8,6 +9,7 @@ require('dotenv').config();
 const app = express();
 
 const routes = require('./routes');
+const initSocket = require('./socket');
 
 // Middleware
 app.use(cors());
@@ -35,6 +37,10 @@ app.use((err, req, res, next) => {
 });
 
 const PORT = process.env.PORT || 3000;
-app.listen(PORT, () => {
+const server = http.createServer(app);
+
+initSocket(server);
+
+server.listen(PORT, () => {
   console.log(`Server is running on port ${PORT}`);
-}); 
+});

--- a/src/socket.js
+++ b/src/socket.js
@@ -1,0 +1,21 @@
+const { Server } = require('socket.io');
+
+function initSocket(httpServer) {
+  const io = new Server(httpServer, {
+    cors: {
+      origin: '*',
+    },
+  });
+
+  io.on('connection', (socket) => {
+    console.log('Client connected', socket.id);
+
+    socket.on('disconnect', () => {
+      console.log('Client disconnected', socket.id);
+    });
+  });
+
+  return io;
+}
+
+module.exports = initSocket;


### PR DESCRIPTION
## Summary
- add socket.io initializer and connect/disconnect logs
- wrap Express app with HTTP server and start socket server
- include socket.io dependency

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6897b1f96210832a8c787948165d84fa