### PR TITLE
Track connected clients in socket server

### DIFF
--- a/src/socket.js
+++ b/src/socket.js
@@ -6,12 +6,16 @@ function initSocket(httpServer) {
       origin: '*',
     },
   });
+  const clients = new Map();
 
   io.on('connection', (socket) => {
+    const { userId } = socket.handshake.auth;
+    clients.set(userId, socket);
     console.log('Client connected', socket.id);
 
     socket.on('disconnect', () => {
       console.log('Client disconnected', socket.id);
+      clients.delete(userId);
     });
   });
 


### PR DESCRIPTION
## Summary
- Track socket connections by user ID using a Map in `initSocket`
- Remove client entry when the socket disconnects

## Testing
- `npm test`
- `pytest` *(fails: No module named 'game_viewer')*

------
https://chatgpt.com/codex/tasks/task_e_6897b32cb98c832a8a838c9f01aed61c