### PR TITLE
docs: document websocket events

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,41 @@ Production mode:
 ```bash
 npm start
 ```
+
+## WebSocket Connection
+
+Real-time updates are delivered over a Socket.IO connection. Clients should
+connect with their user ID to receive personalized events:
+
+```javascript
+import { io } from "socket.io-client";
+
+const socket = io("http://localhost:3000", {
+  auth: { userId: "<USER_ID>" }
+});
+
+socket.on("initialState", ({ queued, games }) => {
+  // queued: { quickplay: boolean, ranked: boolean }
+  // games: array of active games masked for the player
+});
+
+socket.on("queue:update", (status) => {
+  // status: { quickplay: boolean, ranked: boolean }
+});
+
+socket.on("match:found", (match) => {
+  // match: { matchId, gameId, type }
+});
+
+socket.on("game:update", (game) => {
+  // game: { matchId, gameId, board, actions }
+});
+```
+
+Socket.IO automatically attempts to reconnect when the connection drops.
+For best results, listen for `disconnect` and `reconnect` events and refresh
+any application state after reconnecting.
+
 ## API Endpoints
 
 ### Users

--- a/docs/API.md
+++ b/docs/API.md
@@ -33,3 +33,30 @@ time match and move data is streamed to clients via WebSocket events.
 - `POST /api/v1/lobby/enterRanked` – Join the ranked queue
 - `POST /api/v1/lobby/exitRanked` – Leave the ranked queue
 
+## WebSocket Connection
+
+Real-time features use a Socket.IO connection. Clients should connect with
+their user ID to receive personalized events:
+
+```javascript
+import { io } from "socket.io-client";
+
+const socket = io("http://localhost:3000", {
+  auth: { userId: "<USER_ID>" }
+});
+```
+
+### Events
+
+- `initialState` – Emitted once after connecting and contains queue membership
+  and any active games for the player.
+- `queue:update` – Notifies the client when their queue status changes.
+- `match:found` – Sent when matchmaking creates a new match for the player.
+- `game:update` – Provides real-time game state updates.
+
+### Reconnection
+
+Socket.IO will automatically try to reconnect if the connection drops. Listen
+for `disconnect` and `reconnect` events and refresh any needed state after the
+client rejoins.
+


### PR DESCRIPTION
## Summary
- add Socket.IO connection example
- document queue, game, match, and initial state events
- mention reconnection handling in docs

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68991205cc40832ab82ac3a8753ee085