### PR TITLE
Add Google OAuth route and user fields

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "express": "^4.18.2",
     "express-rate-limit": "^7.5.0",
     "express-validator": "^7.2.1",
+    "google-auth-library": "^9.3.0",
     "helmet": "^7.1.0",
     "jsonwebtoken": "^9.0.2",
     "mongoose": "^8.1.0",

--- a/src/models/User.js
+++ b/src/models/User.js
@@ -14,6 +14,10 @@ const userSchema = new mongoose.Schema({
     trim: true,
     lowercase: true
   },
+  photoUrl: {
+    type: String,
+    trim: true
+  },
   elo: {
     type: Number,
     default: 1000,

--- a/src/routes/auth/google.js
+++ b/src/routes/auth/google.js
@@ -1,0 +1,65 @@
+const express = require('express');
+const { OAuth2Client } = require('google-auth-library');
+const User = require('../../models/User');
+
+const router = express.Router();
+
+const scopes = [
+  'openid',
+  'https://www.googleapis.com/auth/userinfo.email',
+  'https://www.googleapis.com/auth/userinfo.profile'
+];
+
+router.get('/google', (req, res) => {
+  const redirectUri = `${req.protocol}://${req.get('host')}/api/auth/google/callback`;
+  const params = new URLSearchParams({
+    client_id: process.env.GOOGLE_CLIENT_ID,
+    redirect_uri: redirectUri,
+    response_type: 'code',
+    scope: scopes.join(' '),
+    access_type: 'offline',
+    prompt: 'consent'
+  });
+  res.redirect(`https://accounts.google.com/o/oauth2/v2/auth?${params.toString()}`);
+});
+
+router.get('/google/callback', async (req, res) => {
+  const code = req.query.code;
+  if (!code) {
+    return res.status(400).json({ message: 'Missing authorization code' });
+  }
+
+  try {
+    const redirectUri = `${req.protocol}://${req.get('host')}/api/auth/google/callback`;
+    const client = new OAuth2Client(
+      process.env.GOOGLE_CLIENT_ID,
+      process.env.GOOGLE_CLIENT_SECRET,
+      redirectUri
+    );
+
+    const { tokens } = await client.getToken(code);
+    const ticket = await client.verifyIdToken({
+      idToken: tokens.id_token,
+      audience: process.env.GOOGLE_CLIENT_ID
+    });
+
+    const payload = ticket.getPayload();
+    const email = payload.email;
+    const photoUrl = payload.picture;
+
+    let user = await User.findOne({ email });
+    if (!user) {
+      user = await User.create({ username: email, email, photoUrl });
+    } else {
+      user.photoUrl = photoUrl;
+      await user.save();
+    }
+
+    res.json({ id: user._id, email: user.email, photoUrl: user.photoUrl });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ message: 'Authentication failed' });
+  }
+});
+
+module.exports = router;

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -1,7 +1,9 @@
 const express = require('express');
 const router = express.Router();
 const v1Routes = require('./v1');
+const authRoutes = require('./auth/google');
 
 router.use('/v1', v1Routes);
+router.use('/auth', authRoutes);
 
 module.exports = router; 


### PR DESCRIPTION
## Summary
- add google OAuth routes for login and callback
- expand User model with photoUrl field
- wire auth routes under `/auth`
- add google-auth-library dependency

## Testing
- `npm test -- --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_68c761761da4832ab88483780b80da49