### PR TITLE
feat: centralize game constants

### DIFF
--- a/docs/shared-constants.md
+++ b/docs/shared-constants.md
@@ -1,0 +1,22 @@
+# Shared game constants
+
+The canonical values used to seed and validate server configuration live in [`shared/constants/game.json`](../shared/constants/game.json). The JSON document is the single source of truth for game modes, colors, identities, move states, and other enumerations that were previously duplicated across models and utilities.
+
+## Runtime entry points
+
+Consumers can load the dataset from either module system without duplicating logic:
+
+- **CommonJS** modules should `require('../../shared/constants')` (adjust the relative path as needed) to receive an immutable object that exposes `GAME_CONSTANTS` as well as named helpers like `gameModes`, `colors`, and `gameModeSettings`.
+- **ES modules** can `import` from `shared/constants/index.mjs`, which uses `createRequire` internally to load the same JSON and re-export the frozen payload.
+
+Both entry points deep-freeze the shared structure so runtime code cannot accidentally mutate the defaults. When a writable copy is required (for example when seeding Mongoose documents) clone the data first, e.g. `JSON.parse(JSON.stringify(GAME_CONSTANTS))`.
+
+## Extending the constants
+
+To add or update a constant:
+
+1. Modify `shared/constants/game.json`. Keep values camel-cased/pascal-cased to match existing keys and preserve numeric encodings used by the database.
+2. Confirm the change is surfaced automatically via the CommonJS and ESM wrappers. No additional updates are needed unless new top-level keys should have dedicated named exports.
+3. Update any documentation or application logic that depends on the new key.
+
+Following this pattern keeps the configuration defaults centralized and prevents drift between the database schema, runtime utilities, and API responses.

--- a/shared/constants/game.json
+++ b/shared/constants/game.json
@@ -1,0 +1,72 @@
+{
+  "gameModes": {
+    "QUICKPLAY": "QUICKPLAY",
+    "RANKED": "RANKED",
+    "CUSTOM": "CUSTOM",
+    "AI": "AI"
+  },
+  "colors": {
+    "WHITE": 0,
+    "BLACK": 1
+  },
+  "identities": {
+    "UNKNOWN": 0,
+    "KING": 1,
+    "BOMB": 2,
+    "BISHOP": 3,
+    "ROOK": 4,
+    "KNIGHT": 5
+  },
+  "actions": {
+    "SETUP": 0,
+    "MOVE": 1,
+    "CHALLENGE": 2,
+    "BOMB": 3,
+    "PASS": 4,
+    "ON_DECK": 5,
+    "RESIGN": 6,
+    "READY": 7
+  },
+  "moveStates": {
+    "PENDING": 0,
+    "COMPLETED": 1,
+    "RESOLVED": 2
+  },
+  "boardDimensions": {
+    "RANKS": 6,
+    "FILES": 5
+  },
+  "gameModeSettings": {
+    "RANKED": {
+      "TIME_CONTROL": 180000,
+      "WIN_SCORE": 3
+    },
+    "QUICKPLAY": {
+      "TIME_CONTROL": 300000,
+      "WIN_SCORE": 1
+    },
+    "INCREMENT": 3000
+  },
+  "gameViewStates": {
+    "WHITE": 0,
+    "BLACK": 1,
+    "SPECTATOR": 2,
+    "ADMIN": 3
+  },
+  "winReasons": {
+    "CAPTURED_KING": 0,
+    "THRONE": 1,
+    "TRUE_KING": 2,
+    "DAGGERS": 3,
+    "TIME_CONTROL": 4,
+    "DISCONNECT": 5,
+    "RESIGN": 6,
+    "DRAW": 7
+  },
+  "gameActionStates": {
+    "CAN_CHALLENGE": 0,
+    "CAN_BOMB": 1,
+    "CAN_PASS": 2,
+    "CAN_RESIGN": 3
+  }
+}

--- a/shared/constants/index.js
+++ b/shared/constants/index.js
@@ -1,0 +1,34 @@
+'use strict';
+
+const gameConstants = require('./game.json');
+
+const deepFreeze = (object) => {
+  if (object && typeof object === 'object' && !Object.isFrozen(object)) {
+    Object.getOwnPropertyNames(object).forEach((name) => {
+      const value = object[name];
+      if (value && typeof value === 'object') {
+        deepFreeze(value);
+      }
+    });
+    Object.freeze(object);
+  }
+  return object;
+};
+
+const GAME_CONSTANTS = deepFreeze(gameConstants);
+
+const exportsPayload = {
+  GAME_CONSTANTS,
+  gameModes: GAME_CONSTANTS.gameModes,
+  colors: GAME_CONSTANTS.colors,
+  identities: GAME_CONSTANTS.identities,
+  actions: GAME_CONSTANTS.actions,
+  moveStates: GAME_CONSTANTS.moveStates,
+  boardDimensions: GAME_CONSTANTS.boardDimensions,
+  gameModeSettings: GAME_CONSTANTS.gameModeSettings,
+  gameViewStates: GAME_CONSTANTS.gameViewStates,
+  winReasons: GAME_CONSTANTS.winReasons,
+  gameActionStates: GAME_CONSTANTS.gameActionStates
+};
+
+module.exports = Object.freeze(exportsPayload);

--- a/shared/constants/index.mjs
+++ b/shared/constants/index.mjs
@@ -1,0 +1,25 @@
+import { createRequire } from 'module';
+
+const require = createRequire(import.meta.url);
+const gameConstants = require('./game.json');
+
+const deepFreeze = (object) => {
+  if (object && typeof object === 'object' && !Object.isFrozen(object)) {
+    Object.getOwnPropertyNames(object).forEach((name) => {
+      const value = object[name];
+      if (value && typeof value === 'object') {
+        deepFreeze(value);
+      }
+    });
+    Object.freeze(object);
+  }
+  return object;
+};
+
+const GAME_CONSTANTS = deepFreeze(gameConstants);
+
+const { gameModes, colors, identities, actions, moveStates, boardDimensions, gameModeSettings, gameViewStates, winReasons, gameActionStates } = GAME_CONSTANTS;
+
+export { GAME_CONSTANTS, gameModes, colors, identities, actions, moveStates, boardDimensions, gameModeSettings, gameViewStates, winReasons, gameActionStates };
+
+export default GAME_CONSTANTS;

--- a/src/models/ServerConfig.js
+++ b/src/models/ServerConfig.js
@@ -1,128 +1,82 @@
 const mongoose = require('mongoose');
+const { GAME_CONSTANTS } = require('../../shared/constants');
 
 const serverConfigSchema = new mongoose.Schema({
   gameModes: {
     type: Map,
     of: String,
-    default: {
-      QUICKPLAY: "QUICKPLAY",
-      RANKED: "RANKED",
-      CUSTOM: "CUSTOM",
-      AI: "AI"
-    }
+    default: () => ({ ...GAME_CONSTANTS.gameModes })
   },
   colors: {
     type: Map,
     of: Number,
-    default: {
-      WHITE: 0,
-      BLACK: 1
-    }
+    default: () => ({ ...GAME_CONSTANTS.colors })
   },
   identities: {
     type: Map,
     of: Number,
-    default: {
-      UNKNOWN: 0,
-      KING: 1,
-      BOMB: 2,
-      BISHOP: 3,
-      ROOK: 4,
-      KNIGHT: 5
-    }
+    default: () => ({ ...GAME_CONSTANTS.identities })
   },
   actions: {
     type: Map,
     of: Number,
-    default: {
-      SETUP: 0,
-      MOVE: 1,
-      CHALLENGE: 2,
-      BOMB: 3,
-      PASS: 4,
-      ON_DECK: 5,
-      RESIGN: 6,
-      READY: 7
-    }
+    default: () => ({ ...GAME_CONSTANTS.actions })
   },
   moveStates: {
     type: Map,
     of: Number,
-    default: {
-      PENDING: 0,
-      COMPLETED: 1,
-      RESOLVED: 2
-    }
+    default: () => ({ ...GAME_CONSTANTS.moveStates })
   },
   boardDimensions: {
     RANKS: {
       type: Number,
-      default: 6
+      default: GAME_CONSTANTS.boardDimensions.RANKS
     },
     FILES: {
       type: Number,
-      default: 5
+      default: GAME_CONSTANTS.boardDimensions.FILES
     }
   },
   gameModeSettings: {
     RANKED: {
       TIME_CONTROL: {
         type: Number,
-        default: 180000
+        default: GAME_CONSTANTS.gameModeSettings.RANKED.TIME_CONTROL
       },
       WIN_SCORE: {
         type: Number,
-        default: 3
+        default: GAME_CONSTANTS.gameModeSettings.RANKED.WIN_SCORE
       }
     },
     QUICKPLAY: {
       TIME_CONTROL: {
         type: Number,
-        default: 300000
+        default: GAME_CONSTANTS.gameModeSettings.QUICKPLAY.TIME_CONTROL
       },
       WIN_SCORE: {
         type: Number,
-        default: 1
+        default: GAME_CONSTANTS.gameModeSettings.QUICKPLAY.WIN_SCORE
       }
     },
     INCREMENT: {
       type: Number,
-      default: 3000
+      default: GAME_CONSTANTS.gameModeSettings.INCREMENT
     }
   },
   gameViewStates: {
     type: Map,
     of: Number,
-    default: {
-      WHITE: 0,
-      BLACK: 1,
-      SPECTATOR: 2,
-      ADMIN: 3
-    }
+    default: () => ({ ...GAME_CONSTANTS.gameViewStates })
   },
   winReasons: {
     type: Map,
     of: Number,
-    default: {
-      CAPTURED_KING: 0,
-      THRONE: 1,
-      TRUE_KING: 2,
-      DAGGERS: 3,
-      TIME_CONTROL: 4,
-      DISCONNECT: 5,
-      RESIGN: 6,
-      DRAW: 7
-    }
+    default: () => ({ ...GAME_CONSTANTS.winReasons })
   },
   gameActionStates: {
     type: Map,
     of: Number,
-    default: {
-      CAN_CHALLENGE: 0,
-      CAN_BOMB: 1,
-      CAN_PASS: 2,
-      CAN_RESIGN: 3
-    }
+    default: () => ({ ...GAME_CONSTANTS.gameActionStates })
   }
 }, { 
   timestamps: true,

--- a/src/utils/getServerConfig.js
+++ b/src/utils/getServerConfig.js
@@ -1,71 +1,5 @@
 const ServerConfig = require('../models/ServerConfig');
-
-const DEFAULT_CONFIG = {
-  gameModes: {
-    QUICKPLAY: 'QUICKPLAY',
-    RANKED: 'RANKED',
-    CUSTOM: 'CUSTOM',
-    AI: 'AI'
-  },
-  colors: {
-    WHITE: 0,
-    BLACK: 1
-  },
-  identities: {
-    UNKNOWN: 0,
-    KING: 1,
-    BOMB: 2,
-    BISHOP: 3,
-    ROOK: 4,
-    KNIGHT: 5
-  },
-  actions: {
-    SETUP: 0,
-    MOVE: 1,
-    CHALLENGE: 2,
-    BOMB: 3,
-    PASS: 4,
-    ON_DECK: 5,
-    RESIGN: 6,
-    READY: 7
-  },
-  moveStates: {
-    PENDING: 0,
-    COMPLETED: 1,
-    RESOLVED: 2
-  },
-  boardDimensions: {
-    RANKS: 6,
-    FILES: 5
-  },
-  gameModeSettings: {
-    RANKED: { TIME_CONTROL: 180000, WIN_SCORE: 3 },
-    QUICKPLAY: { TIME_CONTROL: 300000, WIN_SCORE: 1 },
-    INCREMENT: 3000
-  },
-  gameViewStates: {
-    WHITE: 0,
-    BLACK: 1,
-    SPECTATOR: 2,
-    ADMIN: 3
-  },
-  winReasons: {
-    CAPTURED_KING: 0,
-    THRONE: 1,
-    TRUE_KING: 2,
-    DAGGERS: 3,
-    TIME_CONTROL: 4,
-    DISCONNECT: 5,
-    RESIGN: 6,
-    DRAW: 7
-  },
-  gameActionStates: {
-    CAN_CHALLENGE: 0,
-    CAN_BOMB: 1,
-    CAN_PASS: 2,
-    CAN_RESIGN: 3
-  }
-};
+const { GAME_CONSTANTS: DEFAULT_CONFIG } = require('../../shared/constants');
 
 function toNumber(value) {
   if (value === null || value === undefined) return NaN;
@@ -80,7 +14,7 @@ async function getServerConfig() {
   try {
     let config = await ServerConfig.findOne();
     if (!config) {
-      config = await ServerConfig.create(DEFAULT_CONFIG);
+      config = await ServerConfig.create(JSON.parse(JSON.stringify(DEFAULT_CONFIG)));
     }
 
     const settings = config.gameModeSettings || (config.gameModeSettings = {});
@@ -131,4 +65,4 @@ async function getServerConfig() {
   }
 }
 
-module.exports = getServerConfig; 
+module.exports = getServerConfig;


### PR DESCRIPTION
## Summary
- move the canonical game configuration into a shared JSON dataset
- expose the constants through both CommonJS and ES module entry points
- update server config defaults and documentation to reference the shared data

## Testing
- npm test *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68cba4c3ea64832a9697f3a95124f5f1