### PR TITLE
Refactor UI buttons into shared helper

### DIFF
--- a/docs/ui-buttons.md
+++ b/docs/ui-buttons.md
@@ -1,0 +1,87 @@
+# UI Button Helpers
+
+The shared button helpers exported from [`public/js/modules/ui/buttons.js`](../public/js/modules/ui/buttons.js) centralize layout math, palette management, and event wiring for overlay buttons.
+
+## API
+
+### `renderButton(options)`
+
+Renders a positioned `<button>` into a container, replacing any existing element with the same `id`.
+
+| Option | Type | Description |
+| --- | --- | --- |
+| `id` | `string` | Required DOM id for the button element. |
+| `root` | `HTMLElement` | Parent element that receives the button. |
+| `label` | `string` | Text label shown inside the button. |
+| `variant` | `'primary' \| 'danger' \| 'neutral' \| 'dark'` | Named palette to apply. Custom colors can be supplied via `background`. |
+| `background` | `string` | Optional CSS color to override the palette. |
+| `visible` | `boolean` | When `false`, removes any existing button and stops rendering. |
+| `boardLeft`, `boardTop`, `boardWidth`, `boardHeight` | `number` | Define a rectangular anchor region; the helper centers the button within this area. |
+| `size` | `'auto' \| 'action' \| 'secondary' \| 'large'` | Size preset determining width/height/font ratios. |
+| `sizeBasis` | `number` | Optional dimension used when computing preset sizes (e.g., stash width). |
+| `width`, `height`, `fontSize` | `number` | Explicit overrides for computed measurements. |
+| `zIndex` | `number` | Stack order; defaults to `5`. |
+| `onClick` | `Function` | Click handler attached to the rendered button. |
+
+### `createButton(options)`
+
+Returns an unmounted `<button>` element with consistent styling. It is primarily used internally by `renderButton`, but can be composed in custom flows when direct control is needed.
+
+## Presets & Variants
+
+The helper exposes the registered presets and palette variants for QA snapshots via the named exports `BUTTON_PRESETS` and `BUTTON_VARIANTS`.
+
+| Preset | Description |
+| --- | --- |
+| `auto` | General-purpose sizing driven by the anchor rectangle or parent bounds. |
+| `action` | Slightly larger action buttons sized relative to stash width. |
+| `secondary` | Compact buttons useful for follow-up actions (e.g., Resign/Draw). |
+| `large` | Fixed 160×96 buttons for setup confirmation (Ready). |
+
+| Variant | Background |
+| --- | --- |
+| `primary` | `var(--CG-purple-pressed)` |
+| `danger` | `var(--CG-dark-red)` |
+| `neutral` | `var(--CG-gray)` |
+| `dark` | `var(--CG-black)` |
+
+## Example Gallery (Task 8 Reference)
+
+The snippet below mirrors our lightweight Storybook approach. Paste it into the browser console on `/public/index.html` (after loading the client bundle) to preview each variant without joining a game:
+
+```js
+import { renderButton } from '/js/modules/ui/buttons.js';
+
+const container = document.getElementById('playArea') || document.body;
+const previewRoot = document.createElement('div');
+previewRoot.style.position = 'relative';
+previewRoot.style.width = '400px';
+previewRoot.style.height = '240px';
+previewRoot.style.margin = '24px auto';
+previewRoot.style.background = 'rgba(0,0,0,0.35)';
+previewRoot.style.border = '1px dashed var(--CG-gold)';
+container.appendChild(previewRoot);
+
+const variants = ['primary', 'danger', 'neutral', 'dark'];
+variants.forEach((variant, index) => {
+  renderButton({
+    id: `preview-${variant}`,
+    root: previewRoot,
+    boardLeft: 16 + (index % 2) * 180,
+    boardTop: 24 + Math.floor(index / 2) * 120,
+    boardWidth: 160,
+    boardHeight: 96,
+    label: `${variant} button`,
+    variant,
+    size: index % 2 ? 'secondary' : 'action',
+    onClick: () => console.log(`${variant} clicked`)
+  });
+});
+```
+
+Remove the preview nodes when finished:
+
+```js
+document.querySelectorAll('[id^="preview-"]').forEach(node => node.remove());
+previewRoot.remove();
+```

--- a/public/index.js
+++ b/public/index.js
@@ -2922,7 +2922,6 @@ import {
       const maxBtnW = Math.floor(stashWidth * 0.4);
       const btnW = Math.min(160, maxBtnW);
       const btnH = Math.floor(btnW * 0.6);
-      const fontSize = clamp(Math.round(btnH * 0.28), 13, 22);
       const isMyTurn = currentPlayerTurn === myColor && !isInSetup;
       let canChallenge = false;
       let canBomb = false;
@@ -2963,7 +2962,7 @@ import {
         boardWidth: 0,
         boardHeight: 0,
         text: 'Bomb!',
-        background: 'var(--CG-dark-red)',
+        variant: 'danger',
         visible: canBomb,
         onClick: () => {
           if (!lastGameId) return;
@@ -2971,8 +2970,7 @@ import {
           apiBomb(lastGameId, myColor).catch(err => console.error('Bomb failed', err));
         },
         width: btnW,
-        height: btnH,
-        fontSize
+        height: btnH
       });
 
       // Pass button (uses challenge styling, upper left)
@@ -2984,7 +2982,7 @@ import {
         boardWidth: 0,
         boardHeight: 0,
         text: 'Pass',
-        background: 'var(--CG-purple-pressed)',
+        variant: 'primary',
         visible: canPass,
         onClick: () => {
           if (!lastGameId) return;
@@ -2992,8 +2990,7 @@ import {
           apiPass(lastGameId, myColor).catch(err => console.error('Pass failed', err));
         },
         width: btnW,
-        height: btnH,
-        fontSize
+        height: btnH
       });
 
       // Challenge button (upper right)
@@ -3005,7 +3002,7 @@ import {
         boardWidth: 0,
         boardHeight: 0,
         text: 'Challenge',
-        background: 'var(--CG-purple-pressed)',
+        variant: 'primary',
         visible: canChallenge,
         onClick: () => {
           if (!lastGameId) return;
@@ -3013,8 +3010,7 @@ import {
           apiChallenge(lastGameId, myColor).catch(err => console.error('Challenge failed', err));
         },
         width: btnW,
-        height: btnH,
-        fontSize
+        height: btnH
       });
 
       const deckEl = refs.deckEl;
@@ -3031,7 +3027,6 @@ import {
       const resignTop = deckBottom + gapBelowDeck;
       const resignW = Math.max(1, Math.round(btnW * 0.65));
       const resignH = Math.max(1, Math.round(btnH * 0.5));
-      const resignFontSize = clamp(Math.round(resignH * 0.32), 12, 18);
       const canResign = bothSetupDone && !isInSetup && !gameFinished && Boolean(lastGameId);
       const canOfferDraw = bothSetupDone && !isInSetup && !gameFinished && Boolean(lastGameId) && !hasPendingDrawOffer && !cooldownActive;
 
@@ -3043,20 +3038,18 @@ import {
         boardWidth: 0,
         boardHeight: 0,
         text: 'Resign',
-        background: 'var(--CG-black)',
+        variant: 'dark',
         visible: canResign,
         onClick: () => {
           if (!canResign) return;
           showResignConfirm();
         },
         width: resignW,
-        height: resignH,
-        fontSize: resignFontSize
+        height: resignH
       });
 
       const drawGap = Math.max(4, Math.round(resignH * 0.25));
       const drawTop = resignTop + resignH + drawGap;
-      const drawFontSize = resignFontSize;
 
       renderGameButton({
         id: 'drawBtn',
@@ -3066,15 +3059,14 @@ import {
         boardWidth: 0,
         boardHeight: 0,
         text: 'Draw',
-        background: 'var(--CG-gray)',
+        variant: 'neutral',
         visible: canOfferDraw,
         onClick: () => {
           if (!canOfferDraw) return;
           showDrawConfirm();
         },
         width: resignW,
-        height: resignH,
-        fontSize: drawFontSize
+        height: resignH
       });
     })();
 
@@ -3142,7 +3134,7 @@ import {
       boardWidth: bW,
       boardHeight: bH,
       text: 'Random Setup',
-      background: 'var(--CG-dark-red)',
+      variant: 'danger',
       visible: randomVisible,
       onClick: () => {
         const result = randomizeSetup({

--- a/public/js/modules/render/gameButton.js
+++ b/public/js/modules/render/gameButton.js
@@ -1,75 +1,25 @@
-const clamp = (value, min, max) => Math.min(Math.max(value, min), max);
+import { renderButton } from '../ui/buttons.js';
 
-export function renderGameButton({
-  id,
-  root,
-  boardLeft,
-  boardTop,
-  boardWidth,
-  boardHeight,
-  text,
-  background,
-  visible,
-  onClick,
-  width,
-  height,
-  fontSize
-}) {
-  const existing = document.getElementById(id);
-  if (existing && existing.parentNode) existing.parentNode.removeChild(existing);
-  if (!visible) return;
+export function renderGameButton(options) {
+  if (!options || typeof options !== 'object') return null;
+  const {
+    text,
+    label = text,
+    background,
+    variant,
+    size = 'auto',
+    sizeBasis,
+    ...rest
+  } = options;
 
-  let resolvedWidth;
-  if (typeof width === 'number' && !Number.isNaN(width)) {
-    resolvedWidth = width;
-  } else {
-    const dims = [];
-    if (typeof boardWidth === 'number' && boardWidth > 0) dims.push(boardWidth);
-    if (typeof boardHeight === 'number' && boardHeight > 0) dims.push(boardHeight);
-    let baseRef = dims.length ? Math.max(...dims) : 0;
-    if (!baseRef && root) {
-      const rootWidth = root.clientWidth || 0;
-      const rootHeight = root.clientHeight || 0;
-      baseRef = Math.max(rootWidth, rootHeight);
-    }
-    if (!baseRef) baseRef = 320;
-    const computedWidth = clamp(Math.round(baseRef * 0.32), 80, 160);
-    resolvedWidth = computedWidth;
-  }
-
-  let resolvedHeight;
-  if (typeof height === 'number' && !Number.isNaN(height)) {
-    resolvedHeight = height;
-  } else {
-    const computedHeight = clamp(Math.round(resolvedWidth * 0.6), 48, 96);
-    resolvedHeight = computedHeight;
-  }
-
-  let resolvedFontSize;
-  if (typeof fontSize === 'number' && !Number.isNaN(fontSize)) {
-    resolvedFontSize = fontSize;
-  } else {
-    const computedFont = clamp(Math.round(resolvedHeight * 0.28), 13, 20);
-    resolvedFontSize = computedFont;
-  }
-
-  const btn = document.createElement('button');
-  btn.id = id;
-  btn.textContent = text;
-  btn.style.position = 'absolute';
-  btn.style.left = Math.floor(boardLeft + (boardWidth / 2) - (resolvedWidth / 2)) + 'px';
-  btn.style.top = Math.floor(boardTop + (boardHeight / 2) - (resolvedHeight / 2)) + 'px';
-  btn.style.width = resolvedWidth + 'px';
-  btn.style.height = resolvedHeight + 'px';
-  btn.style.background = background;
-  btn.style.border = '3px solid var(--CG-deep-gold)';
-  btn.style.color = 'var(--CG-white)';
-  btn.style.fontWeight = '800';
-  btn.style.fontSize = resolvedFontSize + 'px';
-  btn.style.cursor = 'pointer';
-  btn.style.zIndex = '5';
-  if (typeof onClick === 'function') btn.addEventListener('click', onClick);
-  root.appendChild(btn);
+  return renderButton({
+    ...rest,
+    label,
+    background,
+    variant,
+    size,
+    sizeBasis
+  });
 }
 
 

--- a/public/js/modules/render/readyButton.js
+++ b/public/js/modules/render/readyButton.js
@@ -1,3 +1,5 @@
+import { renderButton } from '../ui/buttons.js';
+
 export function renderReadyButton({
   root,
   boardLeft,
@@ -7,28 +9,19 @@ export function renderReadyButton({
   isVisible,
   onClick
 }) {
-  // Remove existing
-  const existing = document.getElementById('setupReadyBtn');
-  if (existing && existing.parentNode) existing.parentNode.removeChild(existing);
-  if (!isVisible) return;
-
-  const btn = document.createElement('button');
-  btn.id = 'setupReadyBtn';
-  btn.textContent = 'Ready!';
-  btn.style.position = 'absolute';
-  btn.style.left = Math.floor(boardLeft + (boardWidth / 2) - 80) + 'px';
-  btn.style.top = Math.floor(boardTop + (boardHeight / 2) - 48) + 'px';
-  btn.style.width = '160px';
-  btn.style.height = '96px';
-  btn.style.background = 'var(--CG-purple-pressed)';
-  btn.style.border = '3px solid var(--CG-deep-gold)';
-  btn.style.color = 'var(--CG-white)';
-  btn.style.fontWeight = '800';
-  btn.style.fontSize = '20px';
-  btn.style.cursor = 'pointer';
-  btn.style.zIndex = '5';
-  if (typeof onClick === 'function') btn.addEventListener('click', onClick);
-  root.appendChild(btn);
+  return renderButton({
+    id: 'setupReadyBtn',
+    root,
+    boardLeft,
+    boardTop,
+    boardWidth,
+    boardHeight,
+    visible: isVisible,
+    label: 'Ready!',
+    variant: 'primary',
+    size: 'large',
+    onClick
+  });
 }
 
 

--- a/public/js/modules/ui/buttons.js
+++ b/public/js/modules/ui/buttons.js
@@ -1,0 +1,163 @@
+const clamp = (value, min, max) => Math.min(Math.max(value, min), max);
+
+const SIZE_PRESETS = {
+  auto: {
+    width: { ratio: 0.32, min: 80, max: 160 },
+    height: { ratio: 0.6, min: 48, max: 96, basis: 'width' },
+    fontSize: { ratio: 0.28, min: 13, max: 20, basis: 'height' }
+  },
+  action: {
+    width: { ratio: 0.4, min: 72, max: 160 },
+    height: { ratio: 0.6, min: 44, max: 96, basis: 'width' },
+    fontSize: { ratio: 0.28, min: 13, max: 20, basis: 'height' }
+  },
+  secondary: {
+    width: { ratio: 0.26, min: 56, max: 140 },
+    height: { ratio: 0.6, min: 40, max: 84, basis: 'width' },
+    fontSize: { ratio: 0.3, min: 12, max: 18, basis: 'height' }
+  },
+  large: {
+    width: { fixed: 160 },
+    height: { fixed: 96 },
+    fontSize: { fixed: 20 }
+  }
+};
+
+const PALETTE_VARIANTS = {
+  primary: 'var(--CG-purple-pressed)',
+  danger: 'var(--CG-dark-red)',
+  neutral: 'var(--CG-gray)',
+  dark: 'var(--CG-black)'
+};
+
+function resolvePreset(name) {
+  if (typeof name === 'string' && SIZE_PRESETS[name]) return SIZE_PRESETS[name];
+  return SIZE_PRESETS.auto;
+}
+
+function resolvePalette(variant, background) {
+  if (background) return background;
+  if (variant && PALETTE_VARIANTS[variant]) return PALETTE_VARIANTS[variant];
+  return PALETTE_VARIANTS.primary;
+}
+
+function resolveMeasurement(spec, { baseRef, width, height }) {
+  if (!spec) return null;
+  if (typeof spec.fixed === 'number') return spec.fixed;
+  const basisValue = spec.basis === 'height' ? height : spec.basis === 'width' ? width : baseRef;
+  if (!basisValue || !Number.isFinite(basisValue)) return null;
+  const computed = Math.round(basisValue * (spec.ratio || 1));
+  const min = typeof spec.min === 'number' ? spec.min : computed;
+  const max = typeof spec.max === 'number' ? spec.max : computed;
+  return clamp(computed, min, max);
+}
+
+export function createButton({
+  id,
+  label,
+  variant,
+  background,
+  width,
+  height,
+  fontSize,
+  left,
+  top,
+  zIndex = 5,
+  onClick
+}) {
+  const btn = document.createElement('button');
+  if (id) btn.id = id;
+  btn.type = 'button';
+  btn.textContent = label ?? '';
+  btn.style.position = 'absolute';
+  if (typeof left === 'number') btn.style.left = Math.floor(left) + 'px';
+  if (typeof top === 'number') btn.style.top = Math.floor(top) + 'px';
+  if (typeof width === 'number') btn.style.width = Math.round(width) + 'px';
+  if (typeof height === 'number') btn.style.height = Math.round(height) + 'px';
+  btn.style.background = resolvePalette(variant, background);
+  btn.style.border = '3px solid var(--CG-deep-gold)';
+  btn.style.color = 'var(--CG-white)';
+  btn.style.fontWeight = '800';
+  if (typeof fontSize === 'number') btn.style.fontSize = Math.round(fontSize) + 'px';
+  btn.style.cursor = 'pointer';
+  btn.style.zIndex = String(zIndex);
+  btn.dataset.cgButtonVariant = variant || '';
+  if (typeof onClick === 'function') btn.addEventListener('click', onClick);
+  return btn;
+}
+
+export function renderButton({
+  id,
+  root,
+  label,
+  variant,
+  background,
+  visible = true,
+  onClick,
+  boardLeft = 0,
+  boardTop = 0,
+  boardWidth = 0,
+  boardHeight = 0,
+  size = 'auto',
+  sizeBasis,
+  width,
+  height,
+  fontSize,
+  zIndex
+}) {
+  const existing = id ? document.getElementById(id) : null;
+  if (existing && existing.parentNode) existing.parentNode.removeChild(existing);
+  if (!visible) return null;
+  if (!root) return null;
+
+  const preset = resolvePreset(size);
+  const dims = [];
+  if (typeof sizeBasis === 'number' && sizeBasis > 0) {
+    dims.push(sizeBasis);
+  } else {
+    if (typeof boardWidth === 'number' && boardWidth > 0) dims.push(boardWidth);
+    if (typeof boardHeight === 'number' && boardHeight > 0) dims.push(boardHeight);
+    if (root) {
+      const rootWidth = root.clientWidth || 0;
+      const rootHeight = root.clientHeight || 0;
+      if (rootWidth) dims.push(rootWidth);
+      if (rootHeight) dims.push(rootHeight);
+    }
+  }
+  const baseRef = dims.length ? Math.max(...dims) : 320;
+
+  const resolvedWidth = typeof width === 'number' && !Number.isNaN(width)
+    ? width
+    : resolveMeasurement(preset.width, { baseRef });
+
+  const resolvedHeight = typeof height === 'number' && !Number.isNaN(height)
+    ? height
+    : resolveMeasurement(preset.height, { baseRef, width: resolvedWidth });
+
+  const resolvedFontSize = typeof fontSize === 'number' && !Number.isNaN(fontSize)
+    ? fontSize
+    : resolveMeasurement(preset.fontSize, { baseRef, width: resolvedWidth, height: resolvedHeight });
+
+  const left = Math.floor(boardLeft + (boardWidth / 2) - (resolvedWidth / 2));
+  const top = Math.floor(boardTop + (boardHeight / 2) - (resolvedHeight / 2));
+
+  const button = createButton({
+    id,
+    label,
+    variant,
+    background,
+    width: resolvedWidth,
+    height: resolvedHeight,
+    fontSize: resolvedFontSize,
+    left,
+    top,
+    zIndex,
+    onClick
+  });
+
+  root.appendChild(button);
+  return button;
+}
+
+export const BUTTON_PRESETS = Object.freeze({ ...SIZE_PRESETS });
+export const BUTTON_VARIANTS = Object.freeze({ ...PALETTE_VARIANTS });


### PR DESCRIPTION
## Summary
- add a shared UI button helper that centralizes sizing math, palette variants, and exports preset metadata
- refactor the game and ready button renderers plus their callers to use the helper API and variants
- document the helper along with an example gallery for QA to preview the supported button styles

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cc7f730a94832a9ed75ee9d356027c