### PR TITLE
Add reusable UI overlay shell for modals

### DIFF
--- a/docs/ui-overlays.md
+++ b/docs/ui-overlays.md
@@ -1,0 +1,36 @@
+# UI Overlay Shell
+
+This release introduces a shared overlay shell that handles accessible modal
+behavior for the front-end. All blocking pop-ups now mount through
+`public/js/modules/ui/overlays.js`, which provides:
+
+* ARIA-compliant dialog structure (`role="dialog"`, `aria-modal="true"`).
+* An automatic focus trap and focus restoration when the modal closes.
+* Configurable close controls (including ESC/backdrop support).
+* A reusable content slot that each flow can populate with its own markup.
+
+## Consumers
+
+* **Player history / stats overlay** – opened from the account panel. The close
+  button, backdrop, and Escape key all dismiss the dialog, and tab/shift+tab
+  cycle through the summary/filter controls without leaving the overlay.
+* **Game flow banners** – resign confirmation, draw confirmation, match-found
+  countdown, game-finished summary, and match-complete summary all reuse the
+  shared banner overlay. Each banner now has a consistent close affordance and
+  keeps keyboard focus within the modal content.
+
+## Manual verification checklist
+
+1. Open the account menu → Stats. Confirm focus lands on the overlay close
+   button, Tab stays within the overlay, Escape closes it, and focus returns to
+   the triggering button.
+2. Trigger resign and draw confirmations (from an active game) and verify the
+   modal close button and keyboard focus behave consistently with the stats
+   overlay.
+3. Confirm match-found and post-game banners trap focus, can be dismissed via
+   the shared close control, and do not allow background scrolling while open.
+4. Verify that `returnToLobby()` and other queue-state transitions hide any
+   active overlays and clear countdown timers.
+
+These checks should be performed with only keyboard input to ensure the focus
+trap is effective.

--- a/public/index.html
+++ b/public/index.html
@@ -135,18 +135,101 @@
         height: auto;
       }
 
-      .history-overlay {
+      .cg-overlay {
         position: fixed;
         inset: 0;
-        background: rgba(7, 4, 12, 0.78);
         display: none;
         align-items: center;
         justify-content: center;
+        padding: 16px;
+        z-index: 2500;
+      }
+      .cg-overlay--open { display: flex; }
+      .cg-overlay__backdrop {
+        position: absolute;
+        inset: 0;
+        background: rgba(0,0,0,0.6);
+      }
+      .cg-overlay__dialog {
+        position: relative;
+        z-index: 1;
+        max-height: 90vh;
+        outline: none;
+        display: flex;
+        flex-direction: column;
+      }
+      .cg-overlay__content {
+        position: relative;
+        z-index: 1;
+        display: flex;
+        flex-direction: column;
+        gap: 12px;
+      }
+      .cg-overlay__close {
+        position: absolute;
+        top: 12px;
+        right: 12px;
+        background: none;
+        border: none;
+        color: inherit;
+        font-size: 18px;
+        cursor: pointer;
+      }
+      body.cg-overlay-open { overflow: hidden; }
+
+      .history-overlay {
         padding: 24px;
         z-index: 3000;
       }
-      .history-overlay.open { display: flex; }
+      .history-overlay.open,
+      .history-overlay.cg-overlay--open { display: flex; }
+      .history-overlay .history-overlay-backdrop {
+        background: rgba(7, 4, 12, 0.78);
+      }
       body.history-overlay-open { overflow: hidden; }
+
+      .banner-overlay {
+        padding: 0;
+        z-index: 3200;
+      }
+      .banner-overlay-backdrop {
+        background: rgba(0, 0, 0, 0.55);
+      }
+      .banner-overlay__dialog {
+        width: 100%;
+        height: 100%;
+        background: transparent;
+        border: none;
+        box-shadow: none;
+        padding: 0;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+      }
+      .banner-overlay__content {
+        width: 100%;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        gap: 0;
+      }
+      .banner-overlay__close {
+        position: absolute;
+        top: 12px;
+        right: 12px;
+        background: rgba(0,0,0,0.45);
+        color: var(--CG-white);
+        border: none;
+        border-radius: 4px;
+        padding: 6px 10px;
+        font-size: 18px;
+        cursor: pointer;
+      }
+      .banner-overlay__close:hover {
+        background: rgba(0,0,0,0.65);
+      }
       .history-modal {
         background: rgba(24, 9, 38, 0.95);
         border: 4px solid var(--CG-deep-gold);

--- a/public/js/modules/ui/overlays.js
+++ b/public/js/modules/ui/overlays.js
@@ -1,0 +1,337 @@
+const DEFAULT_FOCUSABLE_SELECTOR = [
+  'a[href]','area[href]','button:not([disabled])','input:not([disabled]):not([type="hidden"])',
+  'select:not([disabled])','textarea:not([disabled])','[tabindex]:not([tabindex="-1"])'
+].join(',');
+
+function resolveDocument(documentRef) {
+  if (documentRef && typeof documentRef.createElement === 'function') {
+    return documentRef;
+  }
+  return document;
+}
+
+function toClassList(value) {
+  if (!value) return [];
+  if (Array.isArray(value)) return value.flatMap(toClassList).filter(Boolean);
+  return String(value).trim().split(/\s+/).filter(Boolean);
+}
+
+function addClasses(node, classes) {
+  if (!node || !classes || classes.length === 0) return;
+  node.classList.add(...classes);
+}
+
+function removeClasses(node, classes) {
+  if (!node || !classes || classes.length === 0) return;
+  node.classList.remove(...classes);
+}
+
+function isElementVisible(el) {
+  if (!el) return false;
+  if (el.hidden) return false;
+  const style = el.ownerDocument && el.ownerDocument.defaultView
+    ? el.ownerDocument.defaultView.getComputedStyle(el)
+    : window.getComputedStyle(el);
+  if (style.visibility === 'hidden' || style.display === 'none') return false;
+  if (typeof el.getClientRects === 'function' && el.getClientRects().length === 0) return false;
+  return true;
+}
+
+function resolveFocusTarget(target, { dialog, content, closeButton }) {
+  if (!target) return null;
+  if (typeof target === 'function') {
+    try { return target({ dialog, content, closeButton }); } catch (_) { return null; }
+  }
+  if (typeof target === 'string') {
+    try { return dialog.querySelector(target) || content.querySelector(target); } catch (_) { return null; }
+  }
+  return target;
+}
+
+export function createOverlay({
+  documentRef,
+  mount,
+  baseClass = 'cg-overlay',
+  openClass = 'cg-overlay--open',
+  bodyOpenClass = 'cg-overlay-open',
+  dialogClass = 'cg-overlay__dialog',
+  contentClass = 'cg-overlay__content',
+  backdropClass = 'cg-overlay__backdrop',
+  closeButtonClass = 'cg-overlay__close',
+  closeLabel = 'Close dialog',
+  closeText = 'Close',
+  showCloseButton = true,
+  closeOnBackdrop = true,
+  closeOnEscape = true,
+  trapFocus = true,
+  labelledBy = null,
+  describedBy = null,
+  ariaLabel = null,
+  id = null,
+  focusableSelector = DEFAULT_FOCUSABLE_SELECTOR,
+  onShow,
+  onHide,
+  onCloseRequest,
+} = {}) {
+  const doc = resolveDocument(documentRef);
+  const root = doc.createElement('div');
+  if (id) root.id = id;
+  addClasses(root, toClassList(baseClass));
+  root.hidden = true;
+  root.setAttribute('aria-hidden', 'true');
+
+  const backdrop = doc.createElement('div');
+  backdrop.className = backdropClass;
+  root.appendChild(backdrop);
+
+  const dialog = doc.createElement('div');
+  dialog.className = dialogClass;
+  dialog.setAttribute('role', 'dialog');
+  dialog.setAttribute('aria-modal', 'true');
+  dialog.setAttribute('aria-hidden', 'true');
+  if (ariaLabel) {
+    dialog.setAttribute('aria-label', ariaLabel);
+  } else if (labelledBy) {
+    dialog.setAttribute('aria-labelledby', labelledBy);
+  }
+  if (describedBy) dialog.setAttribute('aria-describedby', describedBy);
+  dialog.tabIndex = -1;
+
+  const content = doc.createElement('div');
+  content.className = contentClass;
+
+  let closeButton = null;
+  if (showCloseButton) {
+    closeButton = doc.createElement('button');
+    closeButton.type = 'button';
+    closeButton.className = closeButtonClass;
+    closeButton.textContent = closeText;
+    closeButton.setAttribute('aria-label', closeLabel || closeText || 'Close');
+  }
+
+  let focusStart = null;
+  let focusEnd = null;
+  if (trapFocus) {
+    focusStart = doc.createElement('div');
+    focusStart.tabIndex = 0;
+    focusStart.setAttribute('aria-hidden', 'true');
+    focusStart.dataset.overlaySentinel = 'start';
+    focusEnd = doc.createElement('div');
+    focusEnd.tabIndex = 0;
+    focusEnd.setAttribute('aria-hidden', 'true');
+    focusEnd.dataset.overlaySentinel = 'end';
+  }
+
+  if (focusStart) dialog.appendChild(focusStart);
+  if (closeButton) dialog.appendChild(closeButton);
+  dialog.appendChild(content);
+  if (focusEnd) dialog.appendChild(focusEnd);
+  root.appendChild(dialog);
+
+  const mountTarget = mount || doc.body || doc.documentElement || doc;
+  if (mountTarget && typeof mountTarget.appendChild === 'function') {
+    mountTarget.appendChild(root);
+  }
+
+  const openClasses = toClassList(openClass);
+  const bodyOpenClasses = toClassList(bodyOpenClass);
+
+  let isOpen = false;
+  let lastFocusedElement = null;
+  let lastShowOptions = null;
+
+  function getFocusableElements() {
+    const nodes = Array.from(dialog.querySelectorAll(focusableSelector));
+    return nodes.filter(el => {
+      if (el.dataset && el.dataset.overlaySentinel) return false;
+      if (el.hasAttribute('disabled')) return false;
+      if (el.getAttribute && el.getAttribute('aria-hidden') === 'true') return false;
+      if (el.tabIndex < 0) return false;
+      return isElementVisible(el);
+    });
+  }
+
+  function focusFirstAvailable(preferred) {
+    const target = resolveFocusTarget(preferred, { dialog, content, closeButton })
+      || (closeButton && !closeButton.hidden ? closeButton : null);
+    const focusables = getFocusableElements();
+    const fallback = focusables.length > 0 ? focusables[0] : dialog;
+    const el = target && isElementVisible(target) ? target : fallback;
+    if (el && typeof el.focus === 'function') {
+      try { el.focus({ preventScroll: true }); } catch (_) { try { el.focus(); } catch (_) {} }
+    }
+  }
+
+  function handleKeyDown(ev) {
+    if (!isOpen) return;
+    if (closeOnEscape && (ev.key === 'Escape' || ev.key === 'Esc')) {
+      ev.preventDefault();
+      requestClose({ reason: 'escape', event: ev });
+      return;
+    }
+    if (trapFocus && ev.key === 'Tab') {
+      const focusables = getFocusableElements();
+      if (focusables.length === 0) {
+        ev.preventDefault();
+        dialog.focus();
+        return;
+      }
+      const active = doc.activeElement;
+      const currentIndex = focusables.indexOf(active);
+      if (ev.shiftKey) {
+        if (currentIndex <= 0) {
+          ev.preventDefault();
+          focusables[focusables.length - 1].focus();
+        }
+      } else if (currentIndex === focusables.length - 1) {
+        ev.preventDefault();
+        focusables[0].focus();
+      }
+    }
+  }
+
+  function handleSentinelFocus(ev) {
+    if (!isOpen || !trapFocus) return;
+    const focusables = getFocusableElements();
+    if (focusables.length === 0) {
+      dialog.focus();
+      return;
+    }
+    if (ev.target === focusStart) {
+      focusables[focusables.length - 1].focus();
+    } else if (ev.target === focusEnd) {
+      focusables[0].focus();
+    }
+  }
+
+  function handleBackdropPointer(ev) {
+    if (!isOpen || !closeOnBackdrop) return;
+    if (!dialog.contains(ev.target)) {
+      requestClose({ reason: 'backdrop', event: ev });
+    }
+  }
+
+  function handleCloseClick(ev) {
+    requestClose({ reason: 'close-button', event: ev });
+  }
+
+  function requestClose(context = {}) {
+    if (typeof onCloseRequest === 'function') {
+      const shouldClose = onCloseRequest({ ...context, overlay: api });
+      if (shouldClose === false) return;
+    }
+    hide({ restoreFocus: true, reason: context.reason });
+  }
+
+  function show(options = {}) {
+    if (isOpen) return;
+    lastShowOptions = options || {};
+    if (!ariaLabel && options.labelledBy) {
+      dialog.setAttribute('aria-labelledby', options.labelledBy);
+    }
+    if (options.describedBy != null) {
+      if (options.describedBy) dialog.setAttribute('aria-describedby', options.describedBy);
+      else dialog.removeAttribute('aria-describedby');
+    }
+    if (options.ariaLabel) {
+      dialog.setAttribute('aria-label', options.ariaLabel);
+    }
+    if (options.showCloseButton != null && closeButton) {
+      closeButton.hidden = options.showCloseButton === false;
+    }
+    if (options.closeLabel && closeButton) {
+      closeButton.setAttribute('aria-label', options.closeLabel);
+    }
+    if (options.closeText != null && closeButton) {
+      closeButton.textContent = options.closeText;
+    }
+
+    lastFocusedElement = doc.activeElement && typeof doc.activeElement.focus === 'function'
+      ? doc.activeElement
+      : null;
+
+    root.hidden = false;
+    root.setAttribute('aria-hidden', 'false');
+    dialog.setAttribute('aria-hidden', 'false');
+    addClasses(root, openClasses);
+    addClasses(doc.body, bodyOpenClasses);
+    isOpen = true;
+    if (typeof onShow === 'function') {
+      try { onShow(api); } catch (_) {}
+    }
+    if (typeof options.onShow === 'function') {
+      try { options.onShow(api); } catch (_) {}
+    }
+
+    setTimeout(() => {
+      focusFirstAvailable(options.initialFocus);
+    }, 0);
+  }
+
+  function hide({ restoreFocus = true, reason } = {}) {
+    if (!isOpen) return;
+    isOpen = false;
+    removeClasses(root, openClasses);
+    removeClasses(doc.body, bodyOpenClasses);
+    root.setAttribute('aria-hidden', 'true');
+    dialog.setAttribute('aria-hidden', 'true');
+    root.hidden = true;
+    if (typeof onHide === 'function') {
+      try { onHide({ overlay: api, reason }); } catch (_) {}
+    }
+    if (lastShowOptions && typeof lastShowOptions.onHide === 'function') {
+      try { lastShowOptions.onHide({ overlay: api, reason }); } catch (_) {}
+    }
+    const shouldRestore = restoreFocus !== false && lastFocusedElement && typeof lastFocusedElement.focus === 'function';
+    if (shouldRestore) {
+      try { lastFocusedElement.focus({ preventScroll: true }); }
+      catch (_) { try { lastFocusedElement.focus(); } catch (_) {} }
+    }
+    lastFocusedElement = null;
+    lastShowOptions = null;
+  }
+
+  function destroy() {
+    hide({ restoreFocus: false });
+    if (focusStart) focusStart.removeEventListener('focus', handleSentinelFocus);
+    if (focusEnd) focusEnd.removeEventListener('focus', handleSentinelFocus);
+    root.removeEventListener('pointerdown', handleBackdropPointer);
+    dialog.removeEventListener('keydown', handleKeyDown);
+    if (closeButton) closeButton.removeEventListener('click', handleCloseClick);
+    if (root.parentNode) root.parentNode.removeChild(root);
+  }
+
+  if (focusStart) focusStart.addEventListener('focus', handleSentinelFocus);
+  if (focusEnd) focusEnd.addEventListener('focus', handleSentinelFocus);
+  root.addEventListener('pointerdown', handleBackdropPointer);
+  dialog.addEventListener('keydown', handleKeyDown);
+  if (closeButton) closeButton.addEventListener('click', handleCloseClick);
+
+  const api = {
+    element: root,
+    backdrop,
+    dialog,
+    content,
+    closeButton,
+    show,
+    hide,
+    destroy,
+    isOpen: () => isOpen,
+    setLabelledBy(value) {
+      if (!value) dialog.removeAttribute('aria-labelledby');
+      else dialog.setAttribute('aria-labelledby', value);
+    },
+    setDescribedBy(value) {
+      if (!value) dialog.removeAttribute('aria-describedby');
+      else dialog.setAttribute('aria-describedby', value);
+    },
+    setAriaLabel(value) {
+      if (!value) dialog.removeAttribute('aria-label');
+      else dialog.setAttribute('aria-label', value);
+    },
+  };
+
+  return api;
+}
+
+export const focusableSelector = DEFAULT_FOCUSABLE_SELECTOR;


### PR DESCRIPTION
## Summary
- add a shared overlay module that provides focus trapping, backdrop, and close helpers for modals
- refactor the stats dialog and gameplay banners to mount through the shared overlay shell
- document overlay UX expectations and update styling to match the new structure

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cc8567ebc4832abcd7607c083f66d3