### PR TITLE
Harden environment configuration for Google OAuth and Cosmos DB

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,8 +1,0 @@
-WDS_SOCKET_HOST=localhost
-WDS_SOCKET_PORT=0
-DANGEROUSLY_DISABLE_HOST_CHECK=true 
-
-GOOGLE_CLIENT_ID=690242207134-8ga95a9q4saufop814anr9sqhgu2lugb.apps.googleusercontent.com
-GOOGLE_CLIENT_SECRET=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
-SESSION_SECRET=some_random_string_hereasdfasdf
-CLIENT_URL=http://localhost:3000

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,5 @@
+GOOGLE_CLIENT_ID=your-google-client-id-here
+GOOGLE_CLIENT_SECRET=your-google-client-secret-here
+GOOGLE_REDIRECT_URI=http://localhost:3000/api/auth/google/callback
+COSMOSDB_CONNECTION_STRING=mongodb://localhost:27017/cloaks-gambit
+

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ yarn-error.log
 .env
 .env.local
 .env.*.local
+.env.development
 
 # IDE
 .idea/
@@ -30,4 +31,5 @@ coverage/
 
 # Temporary files
 *.tmp
-*.temp 
+*.temp
+

--- a/README.md
+++ b/README.md
@@ -15,12 +15,19 @@ updates are delivered through WebSocket events.
    ```bash
    npm install
    ```
-3. Create a `.env` file in the root directory with the following variables:
-   ```
-   PORT=3000
-   MONGODB_URI=mongodb://localhost:27017/cloaks-gambit
-   NODE_ENV=development
-   ```
+3. Copy `.env.example` to `.env.development` and update the values with your
+   local Google OAuth credentials and MongoDB connection string. This file is
+   ignored by git so each developer can manage their own secrets locally.
+
+## Environment configuration
+
+- **Development:** Environment variables are loaded from `.env.development` via
+  `dotenv`. Ensure you keep this file private and never commit it to version
+  control.
+- **Production:** All secrets must be provided as environment variables (for
+  example via Azure App Service with Key Vault references). The application
+  requires `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET`, `GOOGLE_REDIRECT_URI`,
+  and `COSMOSDB_CONNECTION_STRING` to be defined at runtime.
 
 ## Running the Application
 

--- a/src/routes/auth/google.js
+++ b/src/routes/auth/google.js
@@ -67,62 +67,21 @@ async function buildUsernameFromProfile(payload = {}) {
   return username;
 }
 
-function getEnvValue(...keys) {
-  for (const key of keys) {
-    if (!key) continue;
-    const value = process.env[key];
-    if (value) return value;
-  }
-  return undefined;
-}
-
 function getGoogleClientId() {
-  return getEnvValue(
-    'GOOGLE_CLIENT_ID',
-    'GoogleAuth-ClientID',
-    'GoogleAuth_ClientID',
-    'GoogleAuthClientID'
-  );
+  return process.env.GOOGLE_CLIENT_ID;
 }
 
 function getGoogleClientSecret() {
-  return getEnvValue(
-    'GOOGLE_CLIENT_SECRET',
-    'GoogleAuth-ClientSecret',
-    'GoogleAuth_ClientSecret',
-    'GoogleAuthClientSecret'
-  );
-}
-
-function getGoogleRedirectUri() {
-  return getEnvValue(
-    'GOOGLE_REDIRECT_URI',
-    'GoogleAuth-RedirectURI',
-    'GoogleAuth_RedirectURI',
-    'GoogleAuthRedirectURI',
-    'GoogleAuth-RedirectUrl',
-    'GoogleAuth_RedirectUrl',
-    'GoogleAuthRedirectUrl'
-  );
+  return process.env.GOOGLE_CLIENT_SECRET;
 }
 
 function resolveRedirectUri(req) {
-  const configured = getGoogleRedirectUri();
-  if (configured) {
-    return configured;
+  if (process.env.GOOGLE_REDIRECT_URI) {
+    return process.env.GOOGLE_REDIRECT_URI;
   }
-
-  const forwardedProto = req.get('x-forwarded-proto');
-  const protocol = (forwardedProto ? forwardedProto.split(',')[0].trim() : req.protocol) || 'https';
-  const hostHeader = req.get('x-forwarded-host') || req.get('host');
-  const host = hostHeader ? hostHeader.split(',')[0].trim() : undefined;
-
-  if (!host) {
-    const port = process.env.PORT || 3000;
-    return `${protocol}://localhost:${port}/api/auth/google/callback`;
-  }
-
-  return `${protocol}://${host}/api/auth/google/callback`;
+  // Fallback for dev/local
+  const port = process.env.PORT || 3000;
+  return `http://localhost:${port}/api/auth/google/callback`;
 }
 
 router.get('/google', (req, res) => {

--- a/src/server.js
+++ b/src/server.js
@@ -17,49 +17,20 @@ if (!isProduction) {
   require('dotenv').config({ path: path.resolve(__dirname, '..', envFile) });
 }
 
-function getEnvValue(...keys) {
-  for (const key of keys) {
-    if (!key) continue;
-    const value = process.env[key];
-    if (value) return value;
-  }
-  return undefined;
-}
-
-function getGoogleClientId() {
-  return getEnvValue(
-    'GOOGLE_CLIENT_ID',
-    'GoogleAuth-ClientID',
-    'GoogleAuth_ClientID',
-    'GoogleAuthClientID'
-  );
-}
-
-function getGoogleClientSecret() {
-  return getEnvValue(
-    'GOOGLE_CLIENT_SECRET',
-    'GoogleAuth-ClientSecret',
-    'GoogleAuth_ClientSecret',
-    'GoogleAuthClientSecret'
-  );
-}
-
-const COSMOS_DB_NAME = 'myDatabase';
-const COSMOS_COLLECTION_NAME = 'myCollection';
+const GOOGLE_CLIENT_ID = process.env.GOOGLE_CLIENT_ID;
+const GOOGLE_CLIENT_SECRET = process.env.GOOGLE_CLIENT_SECRET;
+const GOOGLE_REDIRECT_URI = process.env.GOOGLE_REDIRECT_URI;
 const COSMOS_URI = process.env.COSMOSDB_CONNECTION_STRING;
-const GOOGLE_CLIENT_ID = getGoogleClientId();
-const GOOGLE_CLIENT_SECRET = getGoogleClientSecret();
+const COSMOS_COLLECTION_NAME = 'myCollection';
 
 if (isProduction) {
-  const missingSecrets = [];
-  if (!GOOGLE_CLIENT_ID) missingSecrets.push('GOOGLE_CLIENT_ID (or GoogleAuth-ClientID)');
-  if (!GOOGLE_CLIENT_SECRET) missingSecrets.push('GOOGLE_CLIENT_SECRET (or GoogleAuth-ClientSecret)');
-  if (!COSMOS_URI) missingSecrets.push('COSMOSDB_CONNECTION_STRING');
-
-  if (missingSecrets.length > 0) {
-    const message = '❌ Required secrets are missing in production!';
-    console.error(`${message} Missing: ${missingSecrets.join(', ')}. Check Key Vault references.`);
-    throw new Error(message);
+  const missing = [];
+  if (!GOOGLE_CLIENT_ID) missing.push('GOOGLE_CLIENT_ID');
+  if (!GOOGLE_CLIENT_SECRET) missing.push('GOOGLE_CLIENT_SECRET');
+  if (!GOOGLE_REDIRECT_URI) missing.push('GOOGLE_REDIRECT_URI');
+  if (!COSMOS_URI) missing.push('COSMOSDB_CONNECTION_STRING');
+  if (missing.length > 0) {
+    throw new Error(`❌ Required secrets are missing in production: ${missing.join(', ')}`);
   }
 }
 
@@ -95,7 +66,6 @@ async function connectToDatabase() {
 
   const connectionOptions = isProduction
     ? {
-        dbName: COSMOS_DB_NAME,
         serverSelectionTimeoutMS: 10000,
         useNewUrlParser: true,
         useUnifiedTopology: true


### PR DESCRIPTION
## Summary
- fail fast in production when required Google OAuth and Cosmos DB secrets are missing and stop inferring redirect URIs
- read Google OAuth credentials directly from environment variables and use Cosmos DB connection string without extra credentials
- remove the tracked development env file, add an example env template, and document local setup expectations

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d6e606bce4832ab1b5753f228bfe3a