### PR TITLE
Add startup secrets logging

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -23,6 +23,16 @@ const GOOGLE_REDIRECT_URI = process.env.GOOGLE_REDIRECT_URI;
 const COSMOS_URI = process.env.COSMOSDB_CONNECTION_STRING;
 const COSMOS_COLLECTION_NAME = 'myCollection';
 
+const cosmosPreview = COSMOS_URI ? `${COSMOS_URI.slice(0, 60)}${COSMOS_URI.length > 60 ? '…' : ''}` : null;
+
+console.log('Startup secrets check:', {
+  GOOGLE_CLIENT_ID: !!GOOGLE_CLIENT_ID,
+  GOOGLE_CLIENT_SECRET: !!GOOGLE_CLIENT_SECRET,
+  GOOGLE_REDIRECT_URI: !!GOOGLE_REDIRECT_URI,
+  COSMOSDB_CONNECTION_STRING: !!COSMOS_URI,
+  COSMOSDB_CONNECTION_STRING_PREVIEW: cosmosPreview
+});
+
 if (isProduction) {
   const missing = [];
   if (!GOOGLE_CLIENT_ID) missing.push('GOOGLE_CLIENT_ID');


### PR DESCRIPTION
## Summary
- add startup secrets logging after loading environment variables to show whether Google and Cosmos secrets are available
- include a truncated Cosmos connection string preview to help verify Key Vault resolution

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d6f6853354832aa24400207a9edf6a