### PR TITLE
Switch server to MongoDB Atlas configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ updates are delivered through WebSocket events.
 - **Production:** All secrets must be provided as environment variables (for
   example via Azure App Service with Key Vault references). The application
   requires `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET`, `GOOGLE_REDIRECT_URI`,
-  and `COSMOSDB_CONNECTION_STRING` to be defined at runtime.
+  and `MONGODB_ATLAS_CONNECTION_STRING` to be defined at runtime.
 
 ## Running the Application
 


### PR DESCRIPTION
## Summary
- update server startup checks and logging to use the new `MONGODB_ATLAS_CONNECTION_STRING`
- adjust database connection logic to use Atlas in production and local MongoDB for development
- refresh documentation to reference the Atlas environment variable

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d8d3a88020832ab24d2252cbd11250