### PR TITLE
Ensure MongoDB Atlas connections use cloaksgambit database

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,4 +2,5 @@ GOOGLE_CLIENT_ID=your-google-client-id-here
 GOOGLE_CLIENT_SECRET=your-google-client-secret-here
 GOOGLE_REDIRECT_URI=http://localhost:3000/api/auth/google/callback
 COSMOSDB_CONNECTION_STRING=mongodb://localhost:27017/cloaks-gambit
+MONGODB_ATLAS_CONNECTION_STRING=mongodb+srv://user:password@cluster.mongodb.net/cloaksgambit?retryWrites=true&w=majority
 


### PR DESCRIPTION
## Summary
- normalize the MongoDB Atlas connection string so production always targets the cloaksgambit database
- log the database name being used during startup and connection lifecycle
- update the example environment file with an Atlas URI that includes the cloaksgambit database name

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d8d88bc6dc832a8ec85424e012d303