### PR TITLE
Persist authenticated sessions through gameplay

### DIFF
--- a/public/js/modules/api/game.js
+++ b/public/js/modules/api/game.js
@@ -1,26 +1,51 @@
+const TOKEN_STORAGE_KEY = 'cg_token';
+
+function getStoredAuthToken() {
+  try {
+    return localStorage.getItem(TOKEN_STORAGE_KEY);
+  } catch (err) {
+    console.warn('Unable to access localStorage for auth token', err);
+    return null;
+  }
+}
+
+function buildAuthHeaders(base = {}) {
+  const headers = { ...base };
+  const token = getStoredAuthToken();
+  if (token) {
+    headers.Authorization = `Bearer ${token}`;
+  }
+  return headers;
+}
+
+function authFetch(url, options = {}) {
+  const headers = buildAuthHeaders(options.headers || {});
+  return fetch(url, { ...options, headers });
+}
+
 export async function apiReady(gameId, color) {
-  return fetch('/api/v1/gameAction/ready', {
+  return authFetch('/api/v1/gameAction/ready', {
     method: 'POST', headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ gameId, color })
   });
 }
 
 export async function apiNext(gameId, color) {
-  return fetch('/api/v1/gameAction/next', {
+  return authFetch('/api/v1/gameAction/next', {
     method: 'POST', headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ gameId, color })
   });
 }
 
 export async function apiSetup(payload) {
-  return fetch('/api/v1/gameAction/setup', {
+  return authFetch('/api/v1/gameAction/setup', {
     method: 'POST', headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(payload)
   });
 }
 
 export async function apiGetDetails(gameId, color) {
-  const res = await fetch('/api/v1/games/getDetails', {
+  const res = await authFetch('/api/v1/games/getDetails', {
     method: 'POST', headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ gameId, color })
   });
@@ -64,7 +89,7 @@ async function sendQueueRequest(path, payload = {}) {
     }
   }
 
-  const res = await fetch(path, {
+  const res = await authFetch(path, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(body)
@@ -108,63 +133,63 @@ export async function apiExitRankedQueue(payload = {}) {
 }
 
 export async function apiMove({ gameId, color, from, to, declaration }) {
-  return fetch('/api/v1/gameAction/move', {
+  return authFetch('/api/v1/gameAction/move', {
     method: 'POST', headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ gameId, color, from, to, declaration })
   });
 }
 
 export async function apiChallenge(gameId, color) {
-  return fetch('/api/v1/gameAction/challenge', {
+  return authFetch('/api/v1/gameAction/challenge', {
     method: 'POST', headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ gameId, color })
   });
 }
 
 export async function apiBomb(gameId, color) {
-  return fetch('/api/v1/gameAction/bomb', {
+  return authFetch('/api/v1/gameAction/bomb', {
     method: 'POST', headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ gameId, color })
   });
 }
 
 export async function apiPass(gameId, color) {
-  return fetch('/api/v1/gameAction/pass', {
+  return authFetch('/api/v1/gameAction/pass', {
     method: 'POST', headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ gameId, color })
   });
 }
 
 export async function apiResign(gameId, color) {
-  return fetch('/api/v1/gameAction/resign', {
+  return authFetch('/api/v1/gameAction/resign', {
     method: 'POST', headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ gameId, color })
   });
 }
 
 export async function apiDraw(gameId, color, action) {
-  return fetch('/api/v1/gameAction/draw', {
+  return authFetch('/api/v1/gameAction/draw', {
     method: 'POST', headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ gameId, color, action })
   });
 }
 
 export async function apiOnDeck(gameId, color, piece) {
-  return fetch('/api/v1/gameAction/onDeck', {
+  return authFetch('/api/v1/gameAction/onDeck', {
     method: 'POST', headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ gameId, color, piece })
   });
 }
 
 export async function apiCheckTimeControl(gameId) {
-  return fetch('/api/v1/gameAction/checkTimeControl', {
+  return authFetch('/api/v1/gameAction/checkTimeControl', {
     method: 'POST', headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ gameId })
   });
 }
 
 export async function apiGetMatchDetails(matchId) {
-  const res = await fetch('/api/v1/matches/getDetails', {
+  const res = await authFetch('/api/v1/matches/getDetails', {
     method: 'POST', headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ matchId })
   });
@@ -173,7 +198,7 @@ export async function apiGetMatchDetails(matchId) {
 }
 
 export async function apiGetTimeSettings() {
-  const res = await fetch('/api/v1/config/timeSettings');
+  const res = await authFetch('/api/v1/config/timeSettings');
   if (!res.ok) return null;
   return res.json().catch(() => null);
 }

--- a/src/routes/v1/lobby/enterQuickplay.js
+++ b/src/routes/v1/lobby/enterQuickplay.js
@@ -6,17 +6,23 @@ const { checkAndCreateMatches } = require('./matchmaking');
 const eventBus = require('../../../eventBus');
 const mongoose = require('mongoose');
 const ensureUser = require('../../../utils/ensureUser');
+const { resolveUserFromRequest } = require('../../../utils/authTokens');
 
 router.post('/', async (req, res) => {
   try {
-      let { userId } = req.body;
-      let userInfo;
+    let { userId } = req.body;
+    let userInfo = await resolveUserFromRequest(req);
+
+    if (userInfo && userInfo.userId) {
+      userId = userInfo.userId;
+    } else {
       if (!userId) {
         userInfo = await ensureUser();
       } else {
         userInfo = await ensureUser(userId);
       }
       userId = userInfo.userId;
+    }
 
     let lobby = await Lobby.findOne();
     if (!lobby) {

--- a/src/routes/v1/lobby/enterRanked.js
+++ b/src/routes/v1/lobby/enterRanked.js
@@ -6,17 +6,22 @@ const { checkAndCreateMatches } = require('./matchmaking');
 const eventBus = require('../../../eventBus');
 const mongoose = require('mongoose');
 const ensureUser = require('../../../utils/ensureUser');
+const { resolveUserFromRequest } = require('../../../utils/authTokens');
 
 router.post('/', async (req, res) => {
   try {
-      let { userId } = req.body;
-      let userInfo;
+    let { userId } = req.body;
+    let userInfo = await resolveUserFromRequest(req);
+    if (userInfo && userInfo.userId) {
+      userId = userInfo.userId;
+    } else {
       if (!userId) {
         userInfo = await ensureUser();
       } else {
         userInfo = await ensureUser(userId);
       }
       userId = userInfo.userId;
+    }
 
     let lobby = await Lobby.findOne();
     if (!lobby) {

--- a/src/routes/v1/lobby/exitQuickplay.js
+++ b/src/routes/v1/lobby/exitQuickplay.js
@@ -4,19 +4,24 @@ const Lobby = require('../../../models/Lobby');
 const eventBus = require('../../../eventBus');
 const mongoose = require('mongoose');
 const ensureUser = require('../../../utils/ensureUser');
+const { resolveUserFromRequest } = require('../../../utils/authTokens');
 
 router.post('/', async (req, res) => {
   try {
     let { userId } = req.body || {};
-    let userInfo;
+    let userInfo = await resolveUserFromRequest(req);
 
-    if (!userId || !mongoose.isValidObjectId(userId)) {
-      userInfo = await ensureUser();
+    if (userInfo && userInfo.userId) {
+      userId = userInfo.userId;
     } else {
-      userInfo = await ensureUser(userId);
-    }
+      if (!userId || !mongoose.isValidObjectId(userId)) {
+        userInfo = await ensureUser();
+      } else {
+        userInfo = await ensureUser(userId);
+      }
 
-    userId = userInfo.userId;
+      userId = userInfo.userId;
+    }
 
     let lobby = await Lobby.findOne();
     if (!lobby) {

--- a/src/routes/v1/lobby/exitRanked.js
+++ b/src/routes/v1/lobby/exitRanked.js
@@ -4,19 +4,24 @@ const Lobby = require('../../../models/Lobby');
 const eventBus = require('../../../eventBus');
 const mongoose = require('mongoose');
 const ensureUser = require('../../../utils/ensureUser');
+const { resolveUserFromRequest } = require('../../../utils/authTokens');
 
 router.post('/', async (req, res) => {
   try {
     let { userId } = req.body || {};
-    let userInfo;
+    let userInfo = await resolveUserFromRequest(req);
 
-    if (!userId || !mongoose.isValidObjectId(userId)) {
-      userInfo = await ensureUser();
+    if (userInfo && userInfo.userId) {
+      userId = userInfo.userId;
     } else {
-      userInfo = await ensureUser(userId);
-    }
+      if (!userId || !mongoose.isValidObjectId(userId)) {
+        userInfo = await ensureUser();
+      } else {
+        userInfo = await ensureUser(userId);
+      }
 
-    userId = userInfo.userId;
+      userId = userInfo.userId;
+    }
 
     let lobby = await Lobby.findOne();
     if (!lobby) {

--- a/src/utils/authTokens.js
+++ b/src/utils/authTokens.js
@@ -1,0 +1,106 @@
+const jwt = require('jsonwebtoken');
+const User = require('../models/User');
+
+const DEFAULT_SECRET = 'development-secret-change-me';
+const TOKEN_COOKIE_NAME = 'cgToken';
+const TOKEN_HEADER = 'authorization';
+
+function getJwtSecret() {
+  return process.env.JWT_SECRET || DEFAULT_SECRET;
+}
+
+function createAuthToken(user) {
+  if (!user) throw new Error('User is required to create an auth token');
+  const payload = {
+    sub: user._id.toString(),
+    username: user.username || null,
+  };
+  return jwt.sign(payload, getJwtSecret(), { expiresIn: '365d' });
+}
+
+function verifyAuthToken(token) {
+  if (!token) return null;
+  try {
+    return jwt.verify(token, getJwtSecret());
+  } catch (err) {
+    return null;
+  }
+}
+
+function parseCookies(cookieHeader) {
+  if (!cookieHeader || typeof cookieHeader !== 'string') return {};
+  return cookieHeader.split(';').reduce((acc, part) => {
+    const [rawKey, ...rawVal] = part.trim().split('=');
+    if (!rawKey) return acc;
+    const key = decodeURIComponent(rawKey);
+    const value = decodeURIComponent(rawVal.join('=') || '');
+    acc[key] = value;
+    return acc;
+  }, {});
+}
+
+function extractTokenFromRequest(req) {
+  if (!req || typeof req !== 'object') return null;
+
+  const header = req.headers?.[TOKEN_HEADER];
+  if (typeof header === 'string') {
+    const parts = header.split(' ');
+    if (parts.length === 2 && /^Bearer$/i.test(parts[0])) {
+      return parts[1];
+    }
+    if (!header.includes(' ')) {
+      // Allow sending raw token without Bearer prefix for flexibility
+      return header.trim();
+    }
+  }
+
+  const cookieHeader = req.headers?.cookie;
+  if (cookieHeader) {
+    const cookies = parseCookies(cookieHeader);
+    if (cookies[TOKEN_COOKIE_NAME]) {
+      return cookies[TOKEN_COOKIE_NAME];
+    }
+  }
+
+  return null;
+}
+
+async function resolveUserFromToken(token) {
+  const payload = verifyAuthToken(token);
+  if (!payload?.sub) {
+    return null;
+  }
+
+  const user = await User.findById(payload.sub).lean();
+  if (!user) {
+    return null;
+  }
+
+  const userId = user._id.toString();
+  const username = user.username || 'Anonymous';
+  const email = user.email || '';
+  const isGuest = email.endsWith('@guest.local');
+
+  return {
+    userId,
+    username,
+    email,
+    isGuest,
+    user,
+  };
+}
+
+async function resolveUserFromRequest(req) {
+  const token = extractTokenFromRequest(req);
+  if (!token) return null;
+  return resolveUserFromToken(token);
+}
+
+module.exports = {
+  TOKEN_COOKIE_NAME,
+  createAuthToken,
+  extractTokenFromRequest,
+  resolveUserFromRequest,
+  resolveUserFromToken,
+  verifyAuthToken,
+};


### PR DESCRIPTION
## Summary
- add JWT helper utilities and mint a token during Google OAuth to back persisted sessions
- honor auth tokens on lobby routes and socket connections while logging logged-in vs anonymous clients
- persist tokens on the client for API calls and socket handshakes, including the admin dashboard

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d8d8b216ac832a8b413627dc0a7847