### PR TITLE
Ensure next match overlay resets after both players ready

### DIFF
--- a/public/index.js
+++ b/public/index.js
@@ -1927,6 +1927,8 @@ import { createOverlay } from '/js/modules/ui/overlays.js';
       },
       async onBothNext(payload) {
         try {
+          console.log('[socket] players:bothNext received', payload);
+          clearBannerOverlay({ restoreFocus: false });
           const { gameId, color } = payload || {};
           if (!gameId) return;
 
@@ -2157,6 +2159,24 @@ import { createOverlay } from '/js/modules/ui/overlays.js';
 
   function setBannerKeyListener(listener) {
     bannerKeyListener = typeof listener === 'function' ? listener : null;
+  }
+
+  function clearBannerOverlay({ restoreFocus = false } = {}) {
+    if (bannerInterval) {
+      clearInterval(bannerInterval);
+      bannerInterval = null;
+    }
+    setBannerKeyListener(null);
+    if (bannerOverlay) {
+      try {
+        if (bannerOverlay.content) {
+          bannerOverlay.content.innerHTML = '';
+        }
+        bannerOverlay.hide({ restoreFocus });
+      } catch (err) {
+        console.warn('Failed to hide banner overlay', err);
+      }
+    }
   }
 
   function showInviteDeclinedBanner(name, status = 'declined') {
@@ -3418,12 +3438,7 @@ import { createOverlay } from '/js/modules/ui/overlays.js';
   function returnToLobby() {
     hidePlayArea();
     showQueuer();
-    setBannerKeyListener(null);
-    if (bannerInterval) { clearInterval(bannerInterval); bannerInterval = null; }
-    if (bannerOverlay) {
-      bannerOverlay.content.innerHTML = '';
-      bannerOverlay.hide({ restoreFocus: false });
-    }
+    clearBannerOverlay({ restoreFocus: false });
     queuedState.quickplay = false;
     queuedState.ranked = false;
     pendingAction = null;


### PR DESCRIPTION
## Summary
- hide the game over banner as soon as both players choose Next so the new game can start cleanly
- add a shared helper to clear banner overlay state that is reused when returning to the lobby

## Testing
- not run (UI change)


------
https://chatgpt.com/codex/tasks/task_e_68d8da9ef6d8832aa528a59e7919811d