### PR TITLE
Preload client assets on load

### DIFF
--- a/public/admin.js
+++ b/public/admin.js
@@ -1,8 +1,11 @@
 import { computeHistorySummary, describeMatch, buildMatchDetailGrid, normalizeId } from '/js/modules/history/dashboard.js';
 import { createDaggerCounter } from '/js/modules/ui/banners.js';
 import { getCookie } from '/js/modules/utils/cookies.js';
+import { preloadAssets } from '/js/modules/utils/assetPreloader.js';
 
 (function () {
+  preloadAssets();
+
   const origin = window.location.origin.replace(/\/$/, '');
   const socket = io(origin + '/admin');
   const params = new URLSearchParams(window.location.search);

--- a/public/index.js
+++ b/public/index.js
@@ -1,3 +1,4 @@
+import { preloadAssets } from '/js/modules/utils/assetPreloader.js';
 import { pieceGlyph as modulePieceGlyph } from '/js/modules/render/pieceGlyph.js';
 import { renderBoard } from '/js/modules/render/board.js';
 import { renderStash as renderStashModule } from '/js/modules/render/stash.js';
@@ -25,6 +26,8 @@ import {
 } from '/js/modules/ui/icons.js';
 import { createDaggerCounter } from '/js/modules/ui/banners.js';
 import { createOverlay } from '/js/modules/ui/overlays.js';
+
+preloadAssets();
 
 (function() {
   const clamp = (value, min, max) => Math.min(Math.max(value, min), max);

--- a/public/js/modules/utils/assetPreloader.js
+++ b/public/js/modules/utils/assetPreloader.js
@@ -1,0 +1,85 @@
+import { ASSET_MANIFEST } from '/js/shared/assetManifest.js';
+import { PIECE_IMAGES } from '/js/modules/constants.js';
+
+const preloadedSources = new Set();
+const retainedImages = [];
+let baseAssetsPreloaded = false;
+
+const BASE_STATIC_ASSETS = [
+  '/assets/images/Background.png',
+  '/assets/images/UI/menuButton.svg',
+  '/assets/images/account.png',
+  '/assets/images/book.png',
+  '/assets/images/youtube-icon.png',
+  '/assets/images/feedback.png',
+  '/assets/images/byMarcell.webp',
+  '/assets/images/CloakHood.jpg',
+  '/assets/images/google-icon.png',
+  '/assets/images/GoldThrone.svg'
+];
+
+function normalizeAssetUrl(src) {
+  if (typeof src !== 'string') return null;
+  const trimmed = src.trim();
+  if (!trimmed || trimmed.startsWith('data:')) return null;
+  try {
+    const origin = typeof window !== 'undefined' && window.location ? window.location.origin : 'http://localhost';
+    const url = new URL(trimmed, origin);
+    return url.href;
+  } catch (err) {
+    return trimmed;
+  }
+}
+
+function queueImage(src) {
+  const normalized = normalizeAssetUrl(src);
+  if (!normalized || preloadedSources.has(normalized)) return;
+  const img = new Image();
+  img.loading = 'eager';
+  img.decoding = 'async';
+  img.src = normalized;
+  retainedImages.push(img);
+  preloadedSources.add(normalized);
+}
+
+function extractAssetPaths(value, results) {
+  if (!value) return;
+  if (typeof value === 'string') {
+    results.add(value);
+    return;
+  }
+  if (Array.isArray(value)) {
+    value.forEach(item => extractAssetPaths(item, results));
+    return;
+  }
+  if (typeof value === 'object') {
+    Object.values(value).forEach(item => extractAssetPaths(item, results));
+  }
+}
+
+function queueSources(sources) {
+  sources.forEach(src => queueImage(src));
+}
+
+function preloadBaseManifestAssets() {
+  const manifestSources = new Set();
+  extractAssetPaths(ASSET_MANIFEST, manifestSources);
+  extractAssetPaths(PIECE_IMAGES, manifestSources);
+  BASE_STATIC_ASSETS.forEach(src => manifestSources.add(src));
+  queueSources(Array.from(manifestSources));
+}
+
+export function preloadAssets({ additional = [] } = {}) {
+  if (!baseAssetsPreloaded) {
+    preloadBaseManifestAssets();
+    baseAssetsPreloaded = true;
+  }
+  if (Array.isArray(additional) && additional.length > 0) {
+    queueSources(additional);
+  }
+}
+
+export function isAssetPreloaded(src) {
+  const normalized = normalizeAssetUrl(src);
+  return normalized ? preloadedSources.has(normalized) : false;
+}


### PR DESCRIPTION
## Summary
- add an asset preloader utility to eagerly request shared images, icons, and piece sprites
- invoke the preloader from the player and admin entrypoints so assets are cached as soon as modules execute

## Testing
- npm run build:shared

------
https://chatgpt.com/codex/tasks/task_e_68d99c85ca14832a87d8b22dc85a9a79