### PR TITLE
Handle OAuth session persistence and logout cleanup

### DIFF
--- a/public/admin.js
+++ b/public/admin.js
@@ -7,7 +7,7 @@ import { preloadAssets } from '/js/modules/utils/assetPreloader.js';
   preloadAssets();
 
   const origin = window.location.origin.replace(/\/$/, '');
-  const socket = io(origin + '/admin');
+  const socket = io(origin + '/admin', { withCredentials: true });
   const params = new URLSearchParams(window.location.search);
   const adminIdParam = params.get('adminId');
   const adminUserId = adminIdParam || localStorage.getItem('cg_userId') || null;
@@ -53,7 +53,11 @@ import { preloadAssets } from '/js/modules/utils/assetPreloader.js';
     if (token && !headers.Authorization) {
       headers.Authorization = `Bearer ${token}`;
     }
-    return fetch(input, { ...init, headers });
+    const fetchOptions = { ...init, headers };
+    if (!fetchOptions.credentials) {
+      fetchOptions.credentials = 'include';
+    }
+    return fetch(input, fetchOptions);
   }
 
   const tabButtons = Array.from(document.querySelectorAll('.tab-button'));

--- a/public/js/modules/utils/cookies.js
+++ b/public/js/modules/utils/cookies.js
@@ -4,8 +4,18 @@ export function getCookie(name) {
 }
 
 export function setCookie(name, value, maxAgeSeconds) {
-  const parts = [name + '=' + encodeURIComponent(value), 'Path=/', 'SameSite=Lax'];
-  if (maxAgeSeconds) parts.push('Max-Age=' + maxAgeSeconds);
+  const secureContext = typeof window !== 'undefined' && window.location && window.location.protocol === 'https:';
+  const parts = [name + '=' + encodeURIComponent(value), 'Path=/'];
+  const hostname = typeof window !== 'undefined' && window.location ? window.location.hostname : '';
+  if (hostname === 'cloaksgambit.bymarcell.com') {
+    parts.push('Domain=cloaksgambit.bymarcell.com');
+  }
+  if (secureContext) {
+    parts.push('SameSite=None', 'Secure');
+  } else {
+    parts.push('SameSite=Lax');
+  }
+  if (typeof maxAgeSeconds === 'number') parts.push('Max-Age=' + maxAgeSeconds);
   document.cookie = parts.join('; ');
 }
 


### PR DESCRIPTION
## Summary
- centralize Google OAuth cookie options and expose cookie parsing so session logs cover login and logout
- add an authenticated logout endpoint that clears session cookies and logs the removal for diagnostics
- update the client helpers to target the production cookie domain and call the logout endpoint while clearing local state

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68da0715c1c0832ab153b077a4e3f1a2