### PR TITLE
Sync stored identity with session cookies

### DIFF
--- a/public/index.js
+++ b/public/index.js
@@ -1090,12 +1090,30 @@ preloadAssets();
   // Retrieve stored user ID if present; server assigns one if missing
   async function ensureUserId() {
     const stored = getStoredUserId();
-    if (stored) return stored;
+    const cookieId = getCookie('userId');
 
-    const id = getCookie('userId');
-    if (id) {
-      setStoredUserId(id);
-      return id;
+    if (cookieId && cookieId !== stored) {
+      setStoredUserId(cookieId);
+      const cookieName = getCookie('username');
+      setStoredUsername(cookieName || null);
+      return cookieId;
+    }
+
+    if (stored) {
+      if (cookieId === stored) {
+        const cookieName = getCookie('username');
+        if (cookieName) {
+          setStoredUsername(cookieName);
+        }
+      }
+      return stored;
+    }
+
+    if (cookieId) {
+      setStoredUserId(cookieId);
+      const cookieName = getCookie('username');
+      setStoredUsername(cookieName || null);
+      return cookieId;
     }
 
     return null;


### PR DESCRIPTION
## Summary
- sync the cached user identity with the readable session cookies when a cookie-provided account differs from the stored anonymous id
- keep the locally stored username in step with the cookie value so authenticated accounts stop falling back to Anonymous aliases

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68daaa7a29fc832a9bbf1a04e301f06e