### PR TITLE
Move lobby state to in-memory storage

### DIFF
--- a/src/state.js
+++ b/src/state.js
@@ -1,0 +1,13 @@
+const lobbies = {};
+const rankedQueue = [];
+const quickplayQueue = [];
+const matches = new Map();
+const games = new Map();
+
+module.exports = {
+  lobbies,
+  rankedQueue,
+  quickplayQueue,
+  matches,
+  games,
+};


### PR DESCRIPTION
## Summary
- add a shared in-memory state module for lobbies, queues, matches, and games
- initialize the in-memory lobby state on server startup instead of using MongoDB
- rework socket matchmaking, queue updates, and admin metrics to read/write the in-memory structures and emit the appropriate events

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68daf42a09ac832ab0cc7f3f9985b792