### PR TITLE
Persist match results and update user stats

### DIFF
--- a/src/models/User.js
+++ b/src/models/User.js
@@ -1,5 +1,36 @@
 const mongoose = require('mongoose');
 
+const statsSchema = new mongoose.Schema({
+  matchesPlayed: {
+    type: Number,
+    default: 0,
+    min: 0,
+  },
+  matchesWon: {
+    type: Number,
+    default: 0,
+    min: 0,
+  },
+  matchesLost: {
+    type: Number,
+    default: 0,
+    min: 0,
+  },
+  matchesDrawn: {
+    type: Number,
+    default: 0,
+    min: 0,
+  },
+  lastEloDelta: {
+    type: Number,
+    default: 0,
+  },
+  totalEloDelta: {
+    type: Number,
+    default: 0,
+  },
+}, { _id: false });
+
 const userSchema = new mongoose.Schema({
   username: {
     type: String,
@@ -24,6 +55,10 @@ const userSchema = new mongoose.Schema({
     type: Number,
     default: 800,
     min: 0
+  },
+  stats: {
+    type: statsSchema,
+    default: () => ({}),
   },
   createdAt: {
     type: Date,


### PR DESCRIPTION
## Summary
- persist completed match game history to MongoDB when matches end
- update user elo statistics and clean in-memory caches after persistence
- extend the user schema with persistent match statistics fields

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68daf93966e8832a90e90612c236fd34