### PR TITLE
Serve active API data from memory

### DIFF
--- a/src/routes/v1/games/getDetails.js
+++ b/src/routes/v1/games/getDetails.js
@@ -1,7 +1,20 @@
 const express = require('express');
 const router = express.Router();
-const Game = require('../../../models/Game');
 const maskGameForColor = require('../../../utils/gameView');
+const Game = require('../../../models/Game');
+const { games } = require('../../../state');
+
+function cloneGame(game) {
+  if (!game) return null;
+  if (typeof game.toObject === 'function') {
+    return game.toObject({ depopulate: false });
+  }
+  try {
+    return JSON.parse(JSON.stringify(game));
+  } catch (err) {
+    return { ...game };
+  }
+}
 
 router.post('/', async (req, res) => {
   try {
@@ -19,17 +32,20 @@ router.post('/', async (req, res) => {
       }
     }
 
-    const game = await Game.findById(gameId).lean();
-    if (!game) {
+    const memoryGame = games.get(String(gameId));
+    const isActive = Boolean(memoryGame?.isActive);
+    const sourceGame = isActive ? cloneGame(memoryGame) : await Game.findById(gameId).lean();
+
+    if (!sourceGame) {
       return res.status(404).json({ message: 'Game not found' });
     }
 
     // Do not mask anything for admin view
     if (isAdmin) {
-      return res.json(game);
+      return res.json(sourceGame);
     }
 
-    const masked = maskGameForColor(game, normalized);
+    const masked = maskGameForColor(cloneGame(sourceGame), normalized);
     res.json(masked);
   } catch (err) {
     res.status(500).json({ message: err.message });

--- a/src/routes/v1/games/getList.js
+++ b/src/routes/v1/games/getList.js
@@ -1,11 +1,48 @@
 const express = require('express');
 const router = express.Router();
 const Game = require('../../../models/Game');
+const { games: memoryGames } = require('../../../state');
+
+function cloneGame(game) {
+  if (!game) return null;
+  if (typeof game.toObject === 'function') {
+    return game.toObject({ depopulate: false });
+  }
+  try {
+    return JSON.parse(JSON.stringify(game));
+  } catch (err) {
+    return { ...game };
+  }
+}
+
+function matchesUser(game, userId) {
+  if (!userId) return true;
+  const normalized = userId.toString();
+  if (!Array.isArray(game?.players)) return false;
+  return game.players.some((player) => player?.toString?.() === normalized || player === normalized);
+}
+
+function sortByStartTimeDesc(a, b) {
+  const first = new Date(a.startTime || a.createdAt || 0).getTime();
+  const second = new Date(b.startTime || b.createdAt || 0).getTime();
+  return second - first;
+}
 
 router.post('/', async (req, res) => {
   try {
     const { userId, status } = req.body;
-    
+
+    if (String(status).toLowerCase() === 'active') {
+      const activeGames = Array.from(memoryGames.values())
+        .filter((game) => game && game.isActive)
+        .map((game) => cloneGame(game))
+        .filter((game) => game && matchesUser(game, userId))
+        .sort(sortByStartTimeDesc)
+        .slice(0, 50);
+
+      return res.json(activeGames);
+    }
+
     const query = {};
     if (userId) {
       query.$or = [
@@ -17,12 +54,12 @@ router.post('/', async (req, res) => {
       query.isActive = status === 'active';
     }
 
-    const games = await Game.find(query)
+    const historicalGames = await Game.find(query)
       .sort({ createdAt: -1 })
       .limit(50)
       .lean();
 
-    res.json(games);
+    res.json(historicalGames);
   } catch (err) {
     res.status(500).json({ message: err.message });
   }

--- a/src/routes/v1/lobby/get.js
+++ b/src/routes/v1/lobby/get.js
@@ -1,15 +1,25 @@
 const express = require('express');
 const router = express.Router();
-const Lobby = require('../../../models/Lobby');
+const { lobbies, quickplayQueue, rankedQueue } = require('../../../state');
+
+function toIdStrings(values) {
+  if (!Array.isArray(values)) return [];
+  return values.map((value) => {
+    if (!value) return null;
+    if (typeof value === 'string') return value;
+    if (typeof value.toString === 'function') return value.toString();
+    return null;
+  }).filter(Boolean);
+}
 
 router.post('/', async (req, res) => {
   try {
-    let lobby = await Lobby.findOne().lean();
-    if (!lobby) {
-      lobby = await Lobby.create({ quickplayQueue: [], rankedQueue: [] });
-      lobby = lobby.toObject();
-    }
-    res.json(lobby);
+    const lobby = lobbies.default || {};
+    res.json({
+      quickplayQueue: toIdStrings(lobby.quickplayQueue || quickplayQueue),
+      rankedQueue: toIdStrings(lobby.rankedQueue || rankedQueue),
+      inGame: toIdStrings(lobby.inGame),
+    });
   } catch (err) {
     res.status(500).json({ message: err.message });
   }

--- a/src/routes/v1/matches/getDetails.js
+++ b/src/routes/v1/matches/getDetails.js
@@ -1,6 +1,36 @@
 const express = require('express');
 const router = express.Router();
 const Match = require('../../../models/Match');
+const { matches: memoryMatches, games: memoryGames } = require('../../../state');
+
+function clone(value) {
+  if (!value) return null;
+  if (typeof value.toObject === 'function') {
+    return value.toObject({ depopulate: false });
+  }
+  try {
+    return JSON.parse(JSON.stringify(value));
+  } catch (err) {
+    return { ...value };
+  }
+}
+
+function inflateActiveMatch(match) {
+  if (!match) return null;
+  const cloned = clone(match);
+  if (!cloned) return null;
+
+  if (Array.isArray(cloned.games)) {
+    cloned.games = cloned.games
+      .map((id) => {
+        const key = id?.toString?.() || id;
+        const memoryGame = key ? memoryGames.get(key) : null;
+        return clone(memoryGame) || id;
+      });
+  }
+
+  return cloned;
+}
 
 router.post('/', async (req, res) => {
   try {
@@ -8,6 +38,14 @@ router.post('/', async (req, res) => {
 
     if (!matchId) {
       return res.status(400).json({ message: 'matchId is required' });
+    }
+
+    const memoryMatch = memoryMatches.get(matchId?.toString?.() || matchId);
+    if (memoryMatch?.isActive) {
+      const activeMatch = inflateActiveMatch(memoryMatch);
+      if (activeMatch) {
+        return res.json(activeMatch);
+      }
     }
 
     const match = await Match.findById(matchId)

--- a/src/routes/v1/matches/getList.js
+++ b/src/routes/v1/matches/getList.js
@@ -1,10 +1,47 @@
 const express = require('express');
 const router = express.Router();
 const Match = require('../../../models/Match');
+const { matches: memoryMatches } = require('../../../state');
+
+function cloneMatch(match) {
+  if (!match) return null;
+  if (typeof match.toObject === 'function') {
+    return match.toObject({ depopulate: false });
+  }
+  try {
+    return JSON.parse(JSON.stringify(match));
+  } catch (err) {
+    return { ...match };
+  }
+}
+
+function matchIncludesUser(match, userId) {
+  if (!userId) return true;
+  const normalized = userId.toString();
+  const players = [match?.player1, match?.player2];
+  return players.some((player) => player?.toString?.() === normalized || player === normalized);
+}
+
+function sortByStartTimeDesc(a, b) {
+  const first = new Date(a.startTime || a.createdAt || 0).getTime();
+  const second = new Date(b.startTime || b.createdAt || 0).getTime();
+  return second - first;
+}
 
 router.post('/', async (req, res) => {
   try {
     const { userId, status } = req.body;
+
+    if (String(status).toLowerCase() === 'active') {
+      const activeMatches = Array.from(memoryMatches.values())
+        .filter((match) => match && match.isActive)
+        .map((match) => cloneMatch(match))
+        .filter((match) => match && matchIncludesUser(match, userId))
+        .sort(sortByStartTimeDesc)
+        .slice(0, 50);
+
+      return res.json(activeMatches);
+    }
 
     const query = {};
     if (userId) {
@@ -18,12 +55,12 @@ router.post('/', async (req, res) => {
       query.isActive = status === 'active';
     }
 
-    const matches = await Match.find(query)
+    const historicalMatches = await Match.find(query)
       .sort({ startTime: -1 })
       .limit(50)
       .lean();
 
-    res.json(matches);
+    res.json(historicalMatches);
   } catch (err) {
     res.status(500).json({ message: err.message });
   }


### PR DESCRIPTION
## Summary
- serve lobby queue responses from the live in-memory state instead of Mongo
- resolve active game details and listings from the in-memory tracker while falling back to Mongo for history
- surface active match details and listings from in-memory data, reserving Mongo queries for completed matches

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dafcdeb5b4832a90b611709eaf3987