### PR TITLE
Fix username display when stored name updates

### DIFF
--- a/public/index.js
+++ b/public/index.js
@@ -765,8 +765,13 @@ preloadAssets();
     return true;
   }
 
-  function setUsernameDisplay() {
-    const name = getCookie('username') || localStorage.getItem('cg_username');
+  function setUsernameDisplay(nameOverride) {
+    let name = null;
+    if (typeof nameOverride === 'string' && nameOverride.trim() !== '') {
+      name = nameOverride;
+    } else {
+      name = getCookie('username') || localStorage.getItem('cg_username');
+    }
     if (usernameDisplay) {
       usernameDisplay.textContent = name || '';
     }
@@ -1098,6 +1103,7 @@ preloadAssets();
     } catch (err) {
       console.warn('Unable to persist cg_username to localStorage', err);
     }
+    setUsernameDisplay(name || null);
   }
 
   const TOKEN_STORAGE_KEY = 'cg_token';


### PR DESCRIPTION
## Summary
- update the username banner renderer to accept an override so it can reflect the latest stored value
- refresh the username indicator whenever the cached username changes so logged-in players see their name immediately

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68db015ab00c832a9910a80e4089d55f