### PR TITLE
Ensure admin dashboard history uses persisted game data

### DIFF
--- a/public/admin.js
+++ b/public/admin.js
@@ -360,16 +360,17 @@ import { preloadAssets } from '/js/modules/utils/assetPreloader.js';
 
   async function fetchHistoryData() {
     try {
+      const historyRequest = { status: 'completed' };
       const [matchesRes, gamesRes] = await Promise.all([
         authFetch('/api/v1/matches/getList', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({})
+          body: JSON.stringify(historyRequest)
         }),
         authFetch('/api/v1/games/getList', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({})
+          body: JSON.stringify(historyRequest)
         })
       ]);
 


### PR DESCRIPTION
## Summary
- persist finished games from the socket in-memory store to MongoDB whenever they end
- reuse the same persistence helper when archiving matches so the historical collection stays current
- request completed match and game history for the admin dashboard so the history tab reads from MongoDB

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68db0a75aa24832aa9f4ca8c161c957a