### PR TITLE
Add spectate option to Find Game dropdown

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -321,6 +321,7 @@
           <option value="ranked">Ranked</option>
           <option value="custom">Custom</option>
           <option value="bots">Bots</option>
+          <option value="spectate">Spectate</option>
         </select>
         <div class="caret">▾</div>
       </div>

--- a/public/index.js
+++ b/public/index.js
@@ -2113,8 +2113,8 @@ preloadAssets();
   queueBtn.addEventListener('click', async function() {
     let mode = modeSelect.value;
 
-    if (mode === 'bots') {
-      window.alert('Bots coming soon!');
+    if (mode === 'bots' || mode === 'spectate') {
+      window.alert(`${mode === 'spectate' ? 'Spectating' : 'Bots'} coming soon!`);
       return;
     }
 


### PR DESCRIPTION
## Summary
- add a Spectate option beneath Bots in the Find Game dropdown
- show a "Spectating coming soon!" alert when the Spectate mode is selected

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68db61b166d0832a88282a15a92ec00d