### PR TITLE
Fix username update propagation

### DIFF
--- a/public/admin.js
+++ b/public/admin.js
@@ -772,6 +772,27 @@ import { preloadAssets } from '/js/modules/utils/assetPreloader.js';
     }
   });
 
+  socket.on('user:nameUpdated', payload => {
+    try {
+      const id = payload?.userId ? String(payload.userId) : null;
+      const name = typeof payload === 'string' ? payload : payload?.username;
+      if (!id || typeof name !== 'string' || !name.trim()) return;
+      const trimmed = name.trim();
+      usernameMap[id] = trimmed;
+      if (latestMetrics && latestMetrics.usernames) {
+        latestMetrics.usernames[id] = trimmed;
+      }
+      fetchAllUsers();
+      renderActiveMatchesFromState();
+      if (latestMetrics) {
+        renderList(quickplayQueueListEl, latestMetrics.quickplayQueueUserIds);
+        renderList(rankedQueueListEl, latestMetrics.rankedQueueUserIds);
+      }
+    } catch (err) {
+      console.error('Error handling user:nameUpdated event:', err);
+    }
+  });
+
   if (purgeActiveMatchesBtn) {
     purgeActiveMatchesBtn.addEventListener('click', async () => {
       if (!confirm('Are you sure you want to purge all ACTIVE matches from the database? This cannot be undone.')) return;

--- a/public/js/modules/socket.js
+++ b/public/js/modules/socket.js
@@ -12,7 +12,8 @@ export function wireSocket(socket, handlers) {
     onConnectionStatus,
     onInviteRequest,
     onInviteResult,
-    onInviteCancel
+    onInviteCancel,
+    onUserNameUpdated
   } = handlers;
 
   socket.on('connect', () => { try { onConnect && onConnect(); } catch (_) {} });
@@ -27,6 +28,7 @@ export function wireSocket(socket, handlers) {
   socket.on('custom:inviteRequest', (payload) => { try { onInviteRequest && onInviteRequest(payload); } catch (_) {} });
   socket.on('custom:inviteResult', (payload) => { try { onInviteResult && onInviteResult(payload); } catch (_) {} });
   socket.on('custom:inviteCancel', (payload) => { try { onInviteCancel && onInviteCancel(payload); } catch (_) {} });
+  socket.on('user:nameUpdated', (payload) => { try { onUserNameUpdated && onUserNameUpdated(payload); } catch (_) {} });
   socket.on('disconnect', () => { try { onDisconnect && onDisconnect(); } catch (_) {} });
 }
 

--- a/src/socket.js
+++ b/src/socket.js
@@ -562,6 +562,22 @@ function initSocket(httpServer) {
     }
   });
 
+  eventBus.on('user:updated', (payload) => {
+    try {
+      if (!payload) return;
+      const id = toId(payload.userId);
+      if (!id) return;
+      const username = typeof payload.username === 'string' ? payload.username : null;
+      setConnectedUsername(id, username);
+      const message = { userId: id, username };
+      io.emit('user:nameUpdated', message);
+      adminNamespace.emit('user:nameUpdated', message);
+      emitAdminMetrics();
+    } catch (err) {
+      console.error('Error broadcasting user update:', err);
+    }
+  });
+
   eventBus.on('gameChanged', (payload) => {
     let game = payload?.game;
     if (game && typeof game.toObject === 'function') {


### PR DESCRIPTION
## Summary
- emit an internal user:updated event when a username changes so connected sockets refresh cookies and broadcast the change
- teach the client and admin dashboards to react to the new user:nameUpdated socket event and refresh displayed names everywhere
- add socket helper plumbing so username updates reach all listeners consistently

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68db794fe2d8832a8104b01407f50274