### PR TITLE
Fix client auth cache after Google login

### DIFF
--- a/public/admin.js
+++ b/public/admin.js
@@ -37,13 +37,20 @@ import { preloadAssets } from '/js/modules/utils/assetPreloader.js';
   }
 
   function ensureAuthToken() {
+    const cookieToken = getCookie(TOKEN_COOKIE_NAME) || null;
     const stored = getStoredAuthToken();
-    if (stored) return stored;
-    const cookieToken = getCookie(TOKEN_COOKIE_NAME);
+
     if (cookieToken) {
-      setStoredAuthToken(cookieToken);
+      if (stored !== cookieToken) {
+        setStoredAuthToken(cookieToken);
+      }
       return cookieToken;
     }
+
+    if (stored) {
+      setStoredAuthToken(null);
+    }
+
     return null;
   }
 

--- a/public/index.js
+++ b/public/index.js
@@ -968,6 +968,9 @@ preloadAssets();
         setCookie('username', '', 0);
         setCookie('photo', '', 0);
         setCookie('userId', '', 0);
+        setStoredAuthToken(null);
+        setStoredUserId(null);
+        setStoredUsername(null);
         localStorage.removeItem('cg_username');
         window.location.reload();
       });
@@ -1095,13 +1098,20 @@ preloadAssets();
   }
 
   function ensureAuthToken() {
+    const cookieToken = getCookie(TOKEN_COOKIE_NAME) || null;
     const stored = getStoredAuthToken();
-    if (stored) return stored;
-    const cookieToken = getCookie(TOKEN_COOKIE_NAME);
+
     if (cookieToken) {
-      setStoredAuthToken(cookieToken);
+      if (stored !== cookieToken) {
+        setStoredAuthToken(cookieToken);
+      }
       return cookieToken;
     }
+
+    if (stored) {
+      setStoredAuthToken(null);
+    }
+
     return null;
   }
 
@@ -1117,12 +1127,17 @@ preloadAssets();
   // Retrieve stored user ID if present; server assigns one if missing
   async function ensureUserId() {
     const stored = getStoredUserId();
-    if (stored) return stored;
+    const cookieId = getCookie('userId');
 
-    const id = getCookie('userId');
-    if (id) {
-      setStoredUserId(id);
-      return id;
+    if (cookieId) {
+      if (stored !== cookieId) {
+        setStoredUserId(cookieId);
+      }
+      return cookieId;
+    }
+
+    if (stored) {
+      return stored;
     }
 
     return null;


### PR DESCRIPTION
## Summary
- sync the client auth token and user id caches with cookies so the Google login session persists after redirects
- clear cached credentials on logout to avoid reconnecting with stale guest details
- mirror the auth token sync fix on the admin dashboard client

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dbf9626f90832ab576b9cac04bb58c