### PR TITLE
Revamp session handling for guest and Google auth

### DIFF
--- a/src/utils/authTokens.js
+++ b/src/utils/authTokens.js
@@ -99,6 +99,7 @@ async function resolveUserFromRequest(req) {
 module.exports = {
   TOKEN_COOKIE_NAME,
   createAuthToken,
+  parseCookies,
   extractTokenFromRequest,
   resolveUserFromRequest,
   resolveUserFromToken,


### PR DESCRIPTION
## Summary
- add a client-side session bootstrapper that calls the new `/api/auth/session` endpoint and keeps anonymous/login state in sync
- refresh the account panel, socket init, and queue flows to rely on the shared session info and call the new logout endpoint
- add shared cookie helpers plus `/api/auth/session` and `/api/auth/logout` routes on the server while exporting `parseCookies`

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dc0428b1e0832a93e5090e3f7cda32