### PR TITLE
Remove Tournament button from main menu

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -460,7 +460,6 @@
         <div class="menu-buttons">
           <button id="accountBtn" class="menu-button">Account <img src="assets/images/account.png" alt="Account" /></button>
           <button id="rankedLeaderboardBtn" class="menu-button">Ranked <img src="assets/images/rankIcon.png" alt="Ranked" /></button>
-          <button id="tournamentBtn" class="menu-button">Tournament <img src="assets/images/rankIcon.png" alt="Tournament" /></button>
           <a class="menu-button" href="https://drive.google.com/file/d/172IyBX2voKSh7LqQnUWb4dsBzug69ong/view?usp=drive_link" target="_blank" rel="noopener">Rulebook <img src="assets/images/book.png" alt="Rulebook" /></a>
           <a class="menu-button" href="https://youtu.be/MLdMfIYqhaM" target="_blank">Video Rules <img src="assets/images/youtube-icon.png" alt="Video Rules" /></a>
           <a class="menu-button" href="https://forms.gle/72X9cXCe5BM4MN6S7" target="_blank" rel="noopener">Feedback <img src="assets/images/feedback.png" alt="Feedback" /></a>
@@ -514,4 +513,3 @@
     <script type="module" src="/js/main.js?v=__ASSET_VERSION__" defer></script>
   </body>
   </html>
-


### PR DESCRIPTION
### Motivation
- Hide the Tournament entry point from the main menu UI while preserving the existing tournament functionality in code and routes.

### Description
- Removed the `<button id="tournamentBtn">` element from `public/index.html`, leaving all tournament client modules and server endpoints unchanged.

### Testing
- Ran `npm test -- --runInBand` and the test suite passed: 34 test suites passed, 83 tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c5b59d43d0832a8420708f60990c3d)